### PR TITLE
fix: changelist-filter layout bug

### DIFF
--- a/src/unfold/templates/admin/change_list.html
+++ b/src/unfold/templates/admin/change_list.html
@@ -117,7 +117,7 @@
                 {% if cl.has_filters %}
                     <input type="checkbox" id="show-filters" class="hidden peer" />
 
-                    <div id="changelist-filter" class="backdrop-blur-sm bg-opacity-80 bg-gray-900 bottom-0 fixed hidden left-0 mr-1 right-0 top-0 z-50 peer-checked:flex">
+                    <div id="changelist-filter" class="backdrop-blur-sm bg-opacity-80 bg-gray-900 fixed hidden inset-0 z-50 peer-checked:flex">
                         <label for="show-filters" id="changelist-filter-close" class="flex-grow"></label>
 
                         <div class="bg-white flex mr-4 my-4 overflow-hidden rounded shadow-sm w-96 dark:bg-gray-800">


### PR DESCRIPTION
Hi,

there is a small layout bug: when opening filter in a changelist view, the backdrop has an offset from the right border of the browsers window.

<img width="1440" alt="image" src="https://github.com/unfoldadmin/django-unfold/assets/1108485/f1236f03-388b-4687-abe8-1582a988d82d">

Fix:
* remove mr-1

Chore:
* replace {top|bottom|right|left}-0 by inset-0 (same effect with less code)