### PR TITLE
fix: poetry error when used as a local dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,5 +65,5 @@ python = ">=3.8"
 django = ">=3.2"
 
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Tried to use it as described on README.md https://github.com/unfoldadmin/django-unfold#unfold-development but was getting an error.

Using poetry 1.5.1