### PR TITLE
Add compatibility if "tab_list" is missing

### DIFF
--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -12,7 +12,7 @@ register = Library()
 def tab_list(context, opts) -> str:
     tabs = None
 
-    for tab in context.get("tab_list"):
+    for tab in context.get("tab_list", []):
         if str(opts) in tab["models"]:
             tabs = tab["items"]
             break


### PR DESCRIPTION
Fixed simple tag "tab_list" if the behavior is overwritten by other packages

```
TypeError at /admin/<application>/<model>/add/
'NoneType' object is not iterable
```