### PR TITLE
Improve admin.py example for register models

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,20 @@ from django.contrib import admin
 from unfold.admin import ModelAdmin
 
 
-@admin.register(MyModel)
-class CustomAdminClass(ModelAdmin):
-    pass
+@admin.register(MyModel, ModelAdmin)
+```
+
+Or to register all the models of an app with unfold:
+```
+# admin.py
+
+from unfold.admin import ModelAdmin
+from django.apps import apps
+
+post_models = apps.get_app_config('my_app').get_models()
+
+for model in post_models:
+    admin.site.register(model, ModelAdmin)
 ```
 
 **Note:** Registered admin models coming from third party packages are not going to properly work with Unfold because of parent class. By default, these models are registered by using `django.contrib.admin.ModelAdmin` but it is needed to use `unfold.admin.ModelAdmin`. Solution for this problem is to unregister model and then again register it back by using `unfold.admin.ModelAdmin`.


### PR DESCRIPTION
As per title, the `register` method as second parameter accept the class so the code can be simplified.