### PR TITLE
feat(tabs): custom lambda on link

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ def reverse_lazy_change(view, request):
     """
     if 'object_id' in request.resolver_match.kwargs:
         return reverse_lazy(view, args=(request.resolver_match.kwargs['object_id']))
-    return reverse_lazy(view)
+    return reverse_lazy(view + 'list')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -215,12 +215,17 @@ UNFOLD = {
     "TABS": [
         {
             "models": [
-                "app_label.model_name_in_lowercase",
+                "app_label.model_name_in_lowercase", "app_label.model2_name_in_lowercase"
             ],
             "items": [
                 {
                     "title": _("Your custom title"),
                     "link": reverse_lazy("admin:app_label_model_name_changelist"),
+                    "permission": "sample_app.permission_callback",
+                },
+                {
+                    "title": _("Referenced model to object_id"),
+                    "link": lambda request: reverse_lazy_change("admin:app_label_model2_name_change"),
                     "permission": "sample_app.permission_callback",
                 },
             ],
@@ -247,6 +252,17 @@ def badge_callback(request):
 
 def permission_callback(request):
     return request.user.has_perm("sample_app.change_model")
+
+def reverse_lazy_change(view, request):
+    """
+    Generate the view with the object_id of the page.
+
+    '*_change' views require a parameter that usually is the 'object_id' from the same page
+    this means that you can reference a tab to a different model that have the same foreign key.
+    """
+    if 'object_id' in request.resolver_match.kwargs:
+        return reverse_lazy(view, args=(request.resolver_match.kwargs['object_id']))
+    return reverse_lazy(view)
 
 ```
 

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -9,6 +9,7 @@ from django.template.response import TemplateResponse
 from django.urls import URLPattern, path, reverse, reverse_lazy
 from django.utils.functional import lazy
 from django.utils.module_loading import import_string
+import types
 
 from .settings import get_config
 from .widgets import INPUT_CLASSES
@@ -230,13 +231,15 @@ class UnfoldAdminSite(AdminSite):
                     has_tab_link_active = False
 
                     for tab_item in tab["items"]:
+                        if isinstance(tab_item['link'], types.LambdaType) and tab_item['link'].__name__ == "<lambda>":
+                            tab_item['link'] = tab_item['link'](request)
+
                         if item["link"] == tab_item["link"]:
                             has_primary_link = True
                             continue
 
                         if _get_is_active(tab_item["link"]):
                             has_tab_link_active = True
-                            break
 
                     if has_primary_link and has_tab_link_active:
                         item["active"] = True

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -1,3 +1,4 @@
+import types
 from http import HTTPStatus
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -9,7 +10,6 @@ from django.template.response import TemplateResponse
 from django.urls import URLPattern, path, reverse, reverse_lazy
 from django.utils.functional import lazy
 from django.utils.module_loading import import_string
-import types
 
 from .settings import get_config
 from .widgets import INPUT_CLASSES
@@ -231,8 +231,11 @@ class UnfoldAdminSite(AdminSite):
                     has_tab_link_active = False
 
                     for tab_item in tab["items"]:
-                        if isinstance(tab_item['link'], types.LambdaType) and tab_item['link'].__name__ == "<lambda>":
-                            tab_item['link'] = tab_item['link'](request)
+                        if (
+                            isinstance(tab_item["link"], types.LambdaType)
+                            and tab_item["link"].__name__ == "<lambda>"
+                        ):
+                            tab_item["link"] = tab_item["link"](request)
 
                         if item["link"] == tab_item["link"]:
                             has_primary_link = True


### PR DESCRIPTION
![image](https://github.com/unfoldadmin/django-unfold/assets/403283/4c333a82-968b-4b97-8c55-670a0178a79b)

Like in the screenshot but the link for bot the tabs is autogenerated by the object_id so like a page `http://127.0.0.1:8000/admin/portal/user/1/change/` will generate this link for the second tab `http://127.0.0.1:8000/admin/portal/userratings/1/change/`

Ref: #187