### PR TITLE
Enhance Action Lists Based on Target Object for "Detail" and "Submit Line" Actions

### DIFF
--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -423,7 +423,7 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
         """
         return [self.get_unfold_action(action) for action in self.actions_list or []]
 
-    def get_actions_detail(self, request: HttpRequest) -> List[UnfoldAction]:
+    def get_actions_detail(self, request: HttpRequest, object_id: Optional[Any]=None) -> List[UnfoldAction]:
         return self._filter_unfold_actions_by_permissions(
             request, self._get_base_actions_detail()
         )
@@ -445,7 +445,7 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
         """
         return [self.get_unfold_action(action) for action in self.actions_row or []]
 
-    def get_actions_submit_line(self, request: HttpRequest) -> List[UnfoldAction]:
+    def get_actions_submit_line(self, request: HttpRequest, object_id: Optional[Any]=None) -> List[UnfoldAction]:
         return self._filter_unfold_actions_by_permissions(
             request, self._get_base_actions_submit_line()
         )
@@ -540,7 +540,7 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
 
         actions = []
         if object_id:
-            for action in self.get_actions_detail(request):
+            for action in self.get_actions_detail(request, object_id=object_id):
                 actions.append(
                     {
                         "title": action.description,
@@ -553,7 +553,7 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
 
         extra_context.update(
             {
-                "actions_submit_line": self.get_actions_submit_line(request),
+                "actions_submit_line": self.get_actions_submit_line(request, object_id=object_id),
                 "actions_detail": actions,
             }
         )
@@ -619,7 +619,7 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
     ) -> None:
         super().save_model(request, obj, form, change)
 
-        for action in self.get_actions_submit_line(request):
+        for action in self.get_actions_submit_line(request, object_id=obj.pk):
             if action.action_name not in request.POST:
                 continue
 

--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -423,7 +423,9 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
         """
         return [self.get_unfold_action(action) for action in self.actions_list or []]
 
-    def get_actions_detail(self, request: HttpRequest, object_id: Optional[Any]=None) -> List[UnfoldAction]:
+    def get_actions_detail(
+        self, request: HttpRequest, object_id: Optional[Any] = None
+    ) -> List[UnfoldAction]:
         return self._filter_unfold_actions_by_permissions(
             request, self._get_base_actions_detail()
         )
@@ -445,7 +447,9 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
         """
         return [self.get_unfold_action(action) for action in self.actions_row or []]
 
-    def get_actions_submit_line(self, request: HttpRequest, object_id: Optional[Any]=None) -> List[UnfoldAction]:
+    def get_actions_submit_line(
+        self, request: HttpRequest, object_id: Optional[Any] = None
+    ) -> List[UnfoldAction]:
         return self._filter_unfold_actions_by_permissions(
             request, self._get_base_actions_submit_line()
         )
@@ -553,7 +557,9 @@ class ModelAdmin(ModelAdminMixin, BaseModelAdmin):
 
         extra_context.update(
             {
-                "actions_submit_line": self.get_actions_submit_line(request, object_id=object_id),
+                "actions_submit_line": self.get_actions_submit_line(
+                    request, object_id=object_id
+                ),
                 "actions_detail": actions,
             }
         )


### PR DESCRIPTION
## Summary:
This PR introduces the ability to modify the action lists based on the attributes of the target object or instance for 'Detail' and 'Submit Line' actions. This is achieved by passing the `object_id` parameter to the `get_actions_detail` and `get_actions_submit_line` methods, which are called on `changeform_view`. This allows for custom action filtering based on object attributes.

## Changes:
- The `get_actions_submit_line` and `get_actions_detail` methods now accepts an `object_id` parameter.
- Actions can be added or removed based on the attributes of the object.

## Example:
This example demonstrates how to use the new feature. The submit_save_and_publish action is only included in the action list if the book is not published.

```python
# Inside Model Admin
actions_submit_line = ["submit_save_and_publish"]

@action(description=_("Save & Refer"), permissions=["change"])
    def submit_save_and_publish(self, request: HttpRequest, obj: Book):
        obj.published = True
        obj.save()
        return redirect(
            reverse_lazy(
                f"admin:{obj._meta.app_label}_{obj._meta.model_name}_changelist"
            )
        )


def get_actions_submit_line(self, request, object_id=None):
        actions = super().get_actions_submit_line(request=request, object_id=object_id)

        if not object_id:
            return actions

        book = self.get_object(request, object_id=object_id)
        if not book.published:
            actions = [
                action
                for action in actions
                # Action name based on UnfoldAction
                if action.action_name = f"{self.model._meta.app_label}_{self.model._meta.model_name}_submit_save_and_publish"
            ]

        return actions
```
