### PR TITLE
feat: Enable overriding widget classes

### DIFF
--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -48,10 +48,6 @@ from .forms import ActionForm
 from .settings import get_config
 from .typing import FieldsetsType
 from .widgets import (
-    CHECKBOX_LABEL_CLASSES,
-    INPUT_CLASSES,
-    LABEL_CLASSES,
-    SELECT_CLASSES,
     UnfoldAdminBigIntegerFieldWidget,
     UnfoldAdminDecimalFieldWidget,
     UnfoldAdminEmailInputWidget,
@@ -153,9 +149,9 @@ class UnfoldAdminField(helpers.AdminField):
         contents = conditional_escape(self.field.label)
 
         if self.is_checkbox:
-            classes.append(" ".join(CHECKBOX_LABEL_CLASSES))
+            classes.append(" ".join(get_config()["CHECKBOX_LABEL_CLASSES"]))
         else:
-            classes.append(" ".join(LABEL_CLASSES))
+            classes.append(" ".join(get_config()["LABEL_CLASSES"]))
 
         if self.field.field.required:
             classes.append("required")
@@ -176,7 +172,7 @@ helpers.AdminField = UnfoldAdminField
 class UnfoldAdminReadonlyField(helpers.AdminReadonlyField):
     def label_tag(self) -> SafeText:
         attrs = {
-            "class": " ".join(LABEL_CLASSES + ["mb-2"]),
+            "class": " ".join(get_config()["LABEL_CLASSES"] + ["mb-2"]),
         }
 
         label = self.field["label"]
@@ -286,7 +282,7 @@ class ModelAdminMixin:
                 )
             else:
                 kwargs["widget"] = forms.Select(
-                    attrs={"class": " ".join(SELECT_CLASSES)}
+                    attrs={"class": " ".join(get_config()["SELECT_CLASSES"])}
                 )
 
             kwargs["choices"] = db_field.get_choices(
@@ -302,14 +298,14 @@ class ModelAdminMixin:
         if "widget" not in kwargs:
             if db_field.name in self.raw_id_fields:
                 kwargs["widget"] = forms.TextInput(
-                    attrs={"class": " ".join(INPUT_CLASSES)}
+                    attrs={"class": " ".join(get_config()["INPUT_CLASSES"])}
                 )
             elif (
                 db_field.name not in self.get_autocomplete_fields(request)
                 and db_field.name not in self.radio_fields
             ):
                 kwargs["widget"] = forms.Select(
-                    attrs={"class": " ".join(SELECT_CLASSES)}
+                    attrs={"class": " ".join(get_config()["SELECT_CLASSES"])}
                 )
                 kwargs["empty_label"] = _("Select value")
 
@@ -324,7 +320,7 @@ class ModelAdminMixin:
         if "widget" not in kwargs:
             if db_field.name in self.raw_id_fields:
                 kwargs["widget"] = forms.TextInput(
-                    attrs={"class": " ".join(INPUT_CLASSES)}
+                    attrs={"class": " ".join(get_config()["INPUT_CLASSES"])}
                 )
 
         form_field = super().formfield_for_manytomany(db_field, request, **kwargs)
@@ -334,7 +330,7 @@ class ModelAdminMixin:
             return None
 
         if isinstance(form_field.widget, SelectMultiple):
-            form_field.widget.attrs["class"] = " ".join(SELECT_CLASSES)
+            form_field.widget.attrs["class"] = " ".join(get_config()["SELECT_CLASSES"])
 
         return form_field
 
@@ -343,7 +339,7 @@ class ModelAdminMixin:
     ) -> Optional[Field]:
         if "widget" not in kwargs:
             kwargs["widget"] = forms.NullBooleanSelect(
-                attrs={"class": " ".join(SELECT_CLASSES)}
+                attrs={"class": " ".join(get_config()["SELECT_CLASSES"])}
             )
 
         return db_field.formfield(**kwargs)

--- a/src/unfold/contrib/filters/forms.py
+++ b/src/unfold/contrib/filters/forms.py
@@ -1,7 +1,8 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from ...widgets import INPUT_CLASSES, UnfoldAdminSplitDateTimeVerticalWidget
+from ...settings import get_config
+from ...widgets import UnfoldAdminSplitDateTimeVerticalWidget
 
 
 class SingleNumericForm(forms.Form):
@@ -13,7 +14,10 @@ class SingleNumericForm(forms.Form):
             label="",
             required=False,
             widget=forms.NumberInput(
-                attrs={"placeholder": _("Value"), "class": " ".join(INPUT_CLASSES)}
+                attrs={
+                    "placeholder": _("Value"),
+                    "class": " ".join(get_config()["INPUT_CLASSES"]),
+                }
             ),
         )
 
@@ -29,14 +33,20 @@ class RangeNumericForm(forms.Form):
             label="",
             required=False,
             widget=forms.NumberInput(
-                attrs={"placeholder": _("From"), "class": " ".join(INPUT_CLASSES)}
+                attrs={
+                    "placeholder": _("From"),
+                    "class": " ".join(get_config()["INPUT_CLASSES"]),
+                }
             ),
         )
         self.fields[self.name + "_to"] = forms.FloatField(
             label="",
             required=False,
             widget=forms.NumberInput(
-                attrs={"placeholder": _("To"), "class": " ".join(INPUT_CLASSES)}
+                attrs={
+                    "placeholder": _("To"),
+                    "class": " ".join(get_config()["INPUT_CLASSES"]),
+                }
             ),
         )
 
@@ -70,7 +80,8 @@ class RangeDateForm(forms.Form):
             widget=forms.DateInput(
                 attrs={
                     "placeholder": _("From"),
-                    "class": "vCustomDateField " + " ".join(INPUT_CLASSES),
+                    "class": "vCustomDateField "
+                    + " ".join(get_config()["INPUT_CLASSES"]),
                 }
             ),
         )
@@ -80,7 +91,8 @@ class RangeDateForm(forms.Form):
             widget=forms.DateInput(
                 attrs={
                     "placeholder": _("To"),
-                    "class": "vCustomDateField " + " ".join(INPUT_CLASSES),
+                    "class": "vCustomDateField "
+                    + " ".join(get_config()["INPUT_CLASSES"]),
                 }
             ),
         )
@@ -106,12 +118,14 @@ class RangeDateTimeForm(forms.Form):
                 date_label="",
                 date_attrs={
                     "placeholder": _("Date from"),
-                    "class": "vCustomDateField " + " ".join(INPUT_CLASSES),
+                    "class": "vCustomDateField "
+                    + " ".join(get_config()["INPUT_CLASSES"]),
                 },
                 time_label="",
                 time_attrs={
                     "placeholder": _("Time"),
-                    "class": "vCustomTimeField " + " ".join(INPUT_CLASSES),
+                    "class": "vCustomTimeField "
+                    + " ".join(get_config()["INPUT_CLASSES"]),
                 },
             ),
         )
@@ -122,12 +136,14 @@ class RangeDateTimeForm(forms.Form):
                 date_label="",
                 date_attrs={
                     "placeholder": _("Date to"),
-                    "class": "vCustomDateField " + " ".join(INPUT_CLASSES),
+                    "class": "vCustomDateField "
+                    + " ".join(get_config()["INPUT_CLASSES"]),
                 },
                 time_label="",
                 time_attrs={
                     "placeholder": _("Time"),
-                    "class": "vCustomTimeField " + " ".join(INPUT_CLASSES),
+                    "class": "vCustomTimeField "
+                    + " ".join(get_config()["INPUT_CLASSES"]),
                 },
             ),
         )

--- a/src/unfold/contrib/forms/widgets.py
+++ b/src/unfold/contrib/forms/widgets.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Optional
 
 from django.forms import Widget
-from unfold.widgets import PROSE_CLASSES
+from unfold.settings import get_config
 
 WYSIWYG_CLASSES = [
-    *PROSE_CLASSES,
+    *get_config()["PROSE_CLASSES"],
     "border",
     "border-gray-200",
     "border-t-0",

--- a/src/unfold/contrib/import_export/admin.py
+++ b/src/unfold/contrib/import_export/admin.py
@@ -2,7 +2,7 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from import_export.admin import ExportActionModelAdmin as BaseExportActionModelAdmin
 from unfold.admin import ActionForm
-from unfold.widgets import SELECT_CLASSES
+from unfold.settings import get_config
 
 
 def export_action_form_factory(formats):
@@ -12,7 +12,11 @@ def export_action_form_factory(formats):
             choices=formats,
             required=False,
             widget=forms.Select(
-                {"class": " ".join([*SELECT_CLASSES, "ml-3", "!w-auto", "lg:!w-40"])}
+                {
+                    "class": " ".join(
+                        [*get_config()["SELECT_CLASSES"], "ml-3", "!w-auto", "lg:!w-40"]
+                    )
+                }
             ),
         )
 

--- a/src/unfold/contrib/import_export/forms.py
+++ b/src/unfold/contrib/import_export/forms.py
@@ -1,16 +1,21 @@
 from import_export.forms import ExportForm as BaseExportForm
 from import_export.forms import ImportForm as BaseImportForm
-from unfold.widgets import SELECT_CLASSES, UnfoldAdminFileFieldWidget
+from unfold.settings import get_config
+from unfold.widgets import UnfoldAdminFileFieldWidget
 
 
 class ImportForm(BaseImportForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["import_file"].widget = UnfoldAdminFileFieldWidget()
-        self.fields["input_format"].widget.attrs["class"] = " ".join(SELECT_CLASSES)
+        self.fields["input_format"].widget.attrs["class"] = " ".join(
+            get_config()["SELECT_CLASSES"]
+        )
 
 
 class ExportForm(BaseExportForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["file_format"].widget.attrs["class"] = " ".join(SELECT_CLASSES)
+        self.fields["file_format"].widget.attrs["class"] = " ".join(
+            get_config()["SELECT_CLASSES"]
+        )

--- a/src/unfold/forms.py
+++ b/src/unfold/forms.py
@@ -16,13 +16,15 @@ from django.http import HttpRequest
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
-from .widgets import BASE_INPUT_CLASSES, INPUT_CLASSES, SELECT_CLASSES
+from .settings import get_config
 
 
 class ActionForm(forms.Form):
     action = forms.ChoiceField(
         label="",
-        widget=forms.Select({"class": " ".join([*SELECT_CLASSES, "w-72"])}),
+        widget=forms.Select(
+            {"class": " ".join([*get_config()["SELECT_CLASSES"], "w-72"])}
+        ),
     )
 
     select_across = forms.BooleanField(
@@ -42,8 +44,12 @@ class AuthenticationForm(AdminAuthenticationForm):
     ) -> None:
         super().__init__(request, *args, **kwargs)
 
-        self.fields["username"].widget.attrs["class"] = " ".join(BASE_INPUT_CLASSES)
-        self.fields["password"].widget.attrs["class"] = " ".join(BASE_INPUT_CLASSES)
+        self.fields["username"].widget.attrs["class"] = " ".join(
+            get_config()["BASE_INPUT_CLASSES"]
+        )
+        self.fields["password"].widget.attrs["class"] = " ".join(
+            get_config()["BASE_INPUT_CLASSES"]
+        )
 
 
 class UserCreationForm(BaseUserCreationForm):
@@ -55,8 +61,12 @@ class UserCreationForm(BaseUserCreationForm):
     ) -> None:
         super().__init__(request, *args, **kwargs)
 
-        self.fields["password1"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
-        self.fields["password2"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
+        self.fields["password1"].widget.attrs["class"] = " ".join(
+            get_config()["INPUT_CLASSES"]
+        )
+        self.fields["password2"].widget.attrs["class"] = " ".join(
+            get_config()["INPUT_CLASSES"]
+        )
 
 
 class UserChangeForm(BaseUserChangeForm):
@@ -88,14 +98,24 @@ class AdminPasswordChangeForm(BaseAdminPasswordChangeForm):
     ) -> None:
         super().__init__(request, *args, **kwargs)
 
-        self.fields["password1"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
-        self.fields["password2"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
+        self.fields["password1"].widget.attrs["class"] = " ".join(
+            get_config()["INPUT_CLASSES"]
+        )
+        self.fields["password2"].widget.attrs["class"] = " ".join(
+            get_config()["INPUT_CLASSES"]
+        )
 
 
 class AdminOwnPasswordChangeForm(BaseAdminOwnPasswordChangeForm):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(kwargs.pop("user"), *args, **kwargs)
 
-        self.fields["old_password"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
-        self.fields["new_password1"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
-        self.fields["new_password2"].widget.attrs["class"] = " ".join(INPUT_CLASSES)
+        self.fields["old_password"].widget.attrs["class"] = " ".join(
+            get_config()["INPUT_CLASSES"]
+        )
+        self.fields["new_password1"].widget.attrs["class"] = " ".join(
+            get_config()["INPUT_CLASSES"]
+        )
+        self.fields["new_password2"].widget.attrs["class"] = " ".join(
+            get_config()["INPUT_CLASSES"]
+        )

--- a/src/unfold/settings.py
+++ b/src/unfold/settings.py
@@ -41,9 +41,240 @@ CONFIG_DEFAULTS = {
     "EXTENSIONS": {"modeltranslation": {"flags": {}}},
 }
 
+LABEL_CLASSES = [
+    "block",
+    "font-medium",
+    "mb-2",
+    "text-gray-900",
+    "text-sm",
+    "dark:text-gray-200",
+]
+
+CHECKBOX_LABEL_CLASSES = [
+    "ml-2",
+    "text-sm",
+    "text-gray-900",
+    "dark:text-gray-200",
+]
+
+BASE_CLASSES = [
+    "border",
+    "bg-white",
+    "font-medium",
+    "rounded-md",
+    "shadow-sm",
+    "text-gray-500",
+    "text-sm",
+    "focus:ring",
+    "focus:ring-primary-300",
+    "focus:border-primary-600",
+    "focus:outline-none",
+    "group-[.errors]:border-red-600",
+    "group-[.errors]:focus:ring-red-200",
+    "dark:bg-gray-900",
+    "dark:border-gray-700",
+    "dark:text-gray-400",
+    "dark:focus:border-primary-600",
+    "dark:focus:ring-primary-700",
+    "dark:focus:ring-opacity-50",
+    "dark:group-[.errors]:border-red-500",
+    "dark:group-[.errors]:focus:ring-red-600/40",
+]
+
+BASE_INPUT_CLASSES = [
+    *BASE_CLASSES,
+    "px-3",
+    "py-2",
+    "w-full",
+]
+
+INPUT_CLASSES = [*BASE_INPUT_CLASSES, "max-w-2xl"]
+
+COLOR_CLASSES = [*BASE_CLASSES, "h-9.5", "px-2", "py-2", "w-32"]
+
+INPUT_CLASSES_READONLY = [*BASE_INPUT_CLASSES, "bg-gray-50"]
+
+TEXTAREA_CLASSES = [
+    *BASE_INPUT_CLASSES,
+    "max-w-4xl",
+    "appearance-none",
+    "expandable",
+    "overflow-hidden",
+    "transition",
+    "transition-height",
+    "duration-75",
+    "ease-in-out",
+    "resize-none",
+]
+
+TEXTAREA_EXPANDABLE_CLASSES = [
+    "absolute",
+    "bottom-0",
+    "left-0",
+    "right-0",
+    "top-0",
+    "h-full",
+]
+
+SELECT_CLASSES = [
+    *BASE_INPUT_CLASSES,
+    "pr-8",
+    "max-w-2xl",
+    "appearance-none",
+    "truncate",
+]
+
+PROSE_CLASSES = [
+    "font-normal",
+    "prose-sm",
+    "prose-blockquote:border-l-4",
+    "prose-blockquote:not-italic",
+    "prose-pre:bg-gray-50",
+    "prose-pre:rounded",
+    "prose-headings:font-medium",
+    "prose-a:text-primary-600",
+    "prose-a:underline",
+    "prose-headings:font-medium",
+    "prose-headings:text-gray-700",
+    "prose-ol:list-decimal",
+    "prose-ul:list-disc",
+    "prose-strong:text-gray-700",
+    "dark:prose-pre:bg-gray-800",
+    "dark:prose-blockquote:border-gray-700",
+    "dark:prose-blockquote:text-gray-400",
+    "dark:prose-headings:text-gray-200",
+    "dark:prose-strong:text-gray-200",
+]
+
+CHECKBOX_CLASSES = [
+    "appearance-none",
+    "bg-white",
+    "block",
+    "border",
+    "border-gray-300",
+    "cursor-pointer",
+    "h-4",
+    "relative",
+    "rounded",
+    "shadow-sm",
+    "w-4",
+    "hover:border-gray-400",
+    "dark:bg-gray-700",
+    "dark:border-gray-500",
+    "dark:after:checked:text-white",
+    "focus:outline",
+    "focus:outline-1",
+    "focus:outline-offset-2",
+    "focus:outline-primary-500",
+    "after:absolute",
+    "after:content-['done']",
+    "after:!flex",
+    "after:h-4",
+    "after:items-center",
+    "after:justify-center",
+    "after:leading-none",
+    "after:material-symbols-outlined",
+    "after:-ml-px",
+    "after:-mt-px",
+    "after:!text-sm",
+    "after:text-white",
+    "after:transition-all",
+    "after:w-4",
+    "after:dark:text-gray-700",
+    "checked:bg-primary-600",
+    "checked:border-primary-600",
+    "checked:transition-all",
+    "checked:hover:border-primary-600",
+]
+
+RADIO_CLASSES = [
+    "appearance-none",
+    "bg-white",
+    "block",
+    "border",
+    "border-gray-300",
+    "cursor-pointer",
+    "h-4",
+    "relative",
+    "rounded-full",
+    "w-4",
+    "dark:bg-gray-700",
+    "dark:border-gray-500",
+    "hover:border-gray-400",
+    "focus:outline",
+    "focus:outline-1",
+    "focus:outline-offset-2",
+    "focus:outline-primary-500",
+    "after:absolute",
+    "after:bg-white",
+    "after:content-['']",
+    "after:flex",
+    "after:h-2",
+    "after:items-center",
+    "after:justify-center",
+    "after:leading-none",
+    "after:left-1/2",
+    "after:rounded-full",
+    "after:text-white",
+    "after:top-1/2",
+    "after:transition-all",
+    "after:-translate-x-1/2",
+    "after:-translate-y-1/2",
+    "after:text-sm",
+    "after:w-2",
+    "after:dark:text-gray-700",
+    "after:dark:bg-transparent",
+    "checked:bg-primary-600",
+    "checked:border-primary-600",
+    "checked:transition-all",
+    "checked:after:bg-white",
+    "checked:after:dark:bg-gray-200",
+]
+
+SWITCH_CLASSES = [
+    "appearance-none",
+    "bg-gray-300",
+    "cursor-pointer",
+    "h-5",
+    "relative",
+    "rounded-full",
+    "transition-all",
+    "w-8",
+    "after:absolute",
+    "after:bg-white",
+    "after:content-['']",
+    "after:bg-red-300",
+    "after:h-3",
+    "after:rounded-full",
+    "after:shadow-sm",
+    "after:left-1",
+    "after:top-1",
+    "after:w-3",
+    "checked:bg-primary-600",
+    "checked:after:left-4",
+    "dark:bg-gray-600",
+]
+
 
 def get_config(settings_name=None):
     if settings_name is None:
         settings_name = "UNFOLD"
 
-    return {**CONFIG_DEFAULTS, **getattr(settings, settings_name, {})}
+    return {
+        **CONFIG_DEFAULTS,
+        "LABEL_CLASSES": LABEL_CLASSES,
+        "CHECKBOX_LABEL_CLASSES": CHECKBOX_LABEL_CLASSES,
+        "BASE_CLASSES": BASE_CLASSES,
+        "BASE_INPUT_CLASSES": BASE_INPUT_CLASSES,
+        "INPUT_CLASSES": INPUT_CLASSES,
+        "COLOR_CLASSES": COLOR_CLASSES,
+        "INPUT_CLASSES_READONLY": INPUT_CLASSES_READONLY,
+        "TEXTAREA_CLASSES": TEXTAREA_CLASSES,
+        "TEXTAREA_EXPANDABLE_CLASSES": TEXTAREA_EXPANDABLE_CLASSES,
+        "SELECT_CLASSES": SELECT_CLASSES,
+        "PROSE_CLASSES": PROSE_CLASSES,
+        "CHECKBOX_CLASSES": CHECKBOX_CLASSES,
+        "RADIO_CLASSES": RADIO_CLASSES,
+        "SWITCH_CLASSES": SWITCH_CLASSES,
+        **getattr(settings, settings_name, {}),
+    }

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -12,7 +12,6 @@ from django.utils.module_loading import import_string
 
 from .settings import get_config
 from .utils import hex_to_rgb
-from .widgets import CHECKBOX_CLASSES, INPUT_CLASSES
 
 
 class UnfoldAdminSite(AdminSite):
@@ -54,8 +53,8 @@ class UnfoldAdminSite(AdminSite):
         context.update(
             {
                 "form_classes": {
-                    "text_input": INPUT_CLASSES,
-                    "checkbox": CHECKBOX_CLASSES,
+                    "text_input": get_config()["INPUT_CLASSES"],
+                    "checkbox": get_config()["CHECKBOX_CLASSES"],
                 },
                 "site_logo": self._get_mode_images(
                     get_config(self.settings_name)["SITE_LOGO"], request

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -24,237 +24,32 @@ from django.forms import (
 from django.utils.translation import gettext_lazy as _
 
 from .exceptions import UnfoldException
-
-LABEL_CLASSES = [
-    "block",
-    "font-medium",
-    "mb-2",
-    "text-gray-900",
-    "text-sm",
-    "dark:text-gray-200",
-]
-
-CHECKBOX_LABEL_CLASSES = [
-    "ml-2",
-    "text-sm",
-    "text-gray-900",
-    "dark:text-gray-200",
-]
-
-BASE_CLASSES = [
-    "border",
-    "bg-white",
-    "font-medium",
-    "rounded-md",
-    "shadow-sm",
-    "text-gray-500",
-    "text-sm",
-    "focus:ring",
-    "focus:ring-primary-300",
-    "focus:border-primary-600",
-    "focus:outline-none",
-    "group-[.errors]:border-red-600",
-    "group-[.errors]:focus:ring-red-200",
-    "dark:bg-gray-900",
-    "dark:border-gray-700",
-    "dark:text-gray-400",
-    "dark:focus:border-primary-600",
-    "dark:focus:ring-primary-700",
-    "dark:focus:ring-opacity-50",
-    "dark:group-[.errors]:border-red-500",
-    "dark:group-[.errors]:focus:ring-red-600/40",
-]
-
-BASE_INPUT_CLASSES = [
-    *BASE_CLASSES,
-    "px-3",
-    "py-2",
-    "w-full",
-]
-
-INPUT_CLASSES = [*BASE_INPUT_CLASSES, "max-w-2xl"]
-
-COLOR_CLASSES = [*BASE_CLASSES, "h-9.5", "px-2", "py-2", "w-32"]
-
-INPUT_CLASSES_READONLY = [*BASE_INPUT_CLASSES, "bg-gray-50"]
-
-TEXTAREA_CLASSES = [
-    *BASE_INPUT_CLASSES,
-    "max-w-4xl",
-    "appearance-none",
-    "expandable",
-    "overflow-hidden",
-    "transition",
-    "transition-height",
-    "duration-75",
-    "ease-in-out",
-    "resize-none",
-]
-
-TEXTAREA_EXPANDABLE_CLASSES = [
-    "absolute",
-    "bottom-0",
-    "left-0",
-    "right-0",
-    "top-0",
-    "h-full",
-]
-
-SELECT_CLASSES = [
-    *BASE_INPUT_CLASSES,
-    "pr-8",
-    "max-w-2xl",
-    "appearance-none",
-    "truncate",
-]
-
-PROSE_CLASSES = [
-    "font-normal",
-    "prose-sm",
-    "prose-blockquote:border-l-4",
-    "prose-blockquote:not-italic",
-    "prose-pre:bg-gray-50",
-    "prose-pre:rounded",
-    "prose-headings:font-medium",
-    "prose-a:text-primary-600",
-    "prose-a:underline",
-    "prose-headings:font-medium",
-    "prose-headings:text-gray-700",
-    "prose-ol:list-decimal",
-    "prose-ul:list-disc",
-    "prose-strong:text-gray-700",
-    "dark:prose-pre:bg-gray-800",
-    "dark:prose-blockquote:border-gray-700",
-    "dark:prose-blockquote:text-gray-400",
-    "dark:prose-headings:text-gray-200",
-    "dark:prose-strong:text-gray-200",
-]
-
-CHECKBOX_CLASSES = [
-    "appearance-none",
-    "bg-white",
-    "block",
-    "border",
-    "border-gray-300",
-    "cursor-pointer",
-    "h-4",
-    "relative",
-    "rounded",
-    "shadow-sm",
-    "w-4",
-    "hover:border-gray-400",
-    "dark:bg-gray-700",
-    "dark:border-gray-500",
-    "dark:after:checked:text-white",
-    "focus:outline",
-    "focus:outline-1",
-    "focus:outline-offset-2",
-    "focus:outline-primary-500",
-    "after:absolute",
-    "after:content-['done']",
-    "after:!flex",
-    "after:h-4",
-    "after:items-center",
-    "after:justify-center",
-    "after:leading-none",
-    "after:material-symbols-outlined",
-    "after:-ml-px",
-    "after:-mt-px",
-    "after:!text-sm",
-    "after:text-white",
-    "after:transition-all",
-    "after:w-4",
-    "after:dark:text-gray-700",
-    "checked:bg-primary-600",
-    "checked:border-primary-600",
-    "checked:transition-all",
-    "checked:hover:border-primary-600",
-]
-
-RADIO_CLASSES = [
-    "appearance-none",
-    "bg-white",
-    "block",
-    "border",
-    "border-gray-300",
-    "cursor-pointer",
-    "h-4",
-    "relative",
-    "rounded-full",
-    "w-4",
-    "dark:bg-gray-700",
-    "dark:border-gray-500",
-    "hover:border-gray-400",
-    "focus:outline",
-    "focus:outline-1",
-    "focus:outline-offset-2",
-    "focus:outline-primary-500",
-    "after:absolute",
-    "after:bg-white",
-    "after:content-['']",
-    "after:flex",
-    "after:h-2",
-    "after:items-center",
-    "after:justify-center",
-    "after:leading-none",
-    "after:left-1/2",
-    "after:rounded-full",
-    "after:text-white",
-    "after:top-1/2",
-    "after:transition-all",
-    "after:-translate-x-1/2",
-    "after:-translate-y-1/2",
-    "after:text-sm",
-    "after:w-2",
-    "after:dark:text-gray-700",
-    "after:dark:bg-transparent",
-    "checked:bg-primary-600",
-    "checked:border-primary-600",
-    "checked:transition-all",
-    "checked:after:bg-white",
-    "checked:after:dark:bg-gray-200",
-]
-
-SWITCH_CLASSES = [
-    "appearance-none",
-    "bg-gray-300",
-    "cursor-pointer",
-    "h-5",
-    "relative",
-    "rounded-full",
-    "transition-all",
-    "w-8",
-    "after:absolute",
-    "after:bg-white",
-    "after:content-['']",
-    "after:bg-red-300",
-    "after:h-3",
-    "after:rounded-full",
-    "after:shadow-sm",
-    "after:left-1",
-    "after:top-1",
-    "after:w-3",
-    "checked:bg-primary-600",
-    "checked:after:left-4",
-    "dark:bg-gray-600",
-]
+from .settings import get_config
 
 
 class UnfoldAdminTextInputWidget(AdminTextInputWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__(attrs={"class": " ".join(INPUT_CLASSES), **(attrs or {})})
+        super().__init__(
+            attrs={"class": " ".join(get_config()["INPUT_CLASSES"]), **(attrs or {})}
+        )
 
 
 class UnfoldAdminColorInputWidget(AdminTextInputWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(
-            attrs={"type": "color", "class": " ".join(COLOR_CLASSES), **(attrs or {})}
+            attrs={
+                "type": "color",
+                "class": " ".join(get_config()["COLOR_CLASSES"]),
+                **(attrs or {}),
+            }
         )
 
 
 class UnfoldAdminUUIDInputWidget(AdminUUIDInputWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__(attrs={"class": " ".join(INPUT_CLASSES), **(attrs or {})})
+        super().__init__(
+            attrs={"class": " ".join(get_config()["INPUT_CLASSES"]), **(attrs or {})}
+        )
 
 
 class UnfoldAdminIntegerRangeWidget(MultiWidget):
@@ -264,7 +59,7 @@ class UnfoldAdminIntegerRangeWidget(MultiWidget):
         if attrs is None:
             attrs = {}
 
-        attrs["class"] = " ".join(INPUT_CLASSES)
+        attrs["class"] = " ".join(get_config()["INPUT_CLASSES"])
 
         _widgets = (NumberInput(attrs=attrs), NumberInput(attrs=attrs))
 
@@ -278,14 +73,20 @@ class UnfoldAdminIntegerRangeWidget(MultiWidget):
 
 class UnfoldAdminEmailInputWidget(AdminEmailInputWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__(attrs={"class": " ".join(INPUT_CLASSES), **(attrs or {})})
+        super().__init__(
+            attrs={"class": " ".join(get_config()["INPUT_CLASSES"]), **(attrs or {})}
+        )
 
 
 class FileFieldMixin:
     def get_context(self, name, value, attrs):
         widget = super().get_context(name, value, attrs)
         widget["widget"].update(
-            {"class": " ".join([*CHECKBOX_CLASSES, *["form-check-input"]])}
+            {
+                "class": " ".join(
+                    [*get_config()["CHECKBOX_CLASSES"], *["form-check-input"]]
+                )
+            }
         )
         return widget
 
@@ -307,7 +108,7 @@ class UnfoldAdminDateWidget(AdminDateWidget):
         self, attrs: Optional[Dict[str, Any]] = None, format: Optional[str] = None
     ) -> None:
         attrs = {
-            "class": "vDateField " + " ".join(INPUT_CLASSES),
+            "class": "vDateField " + " ".join(get_config()["INPUT_CLASSES"]),
             "size": "10",
             **(attrs or {}),
         }
@@ -321,7 +122,7 @@ class UnfoldAdminSingleDateWidget(AdminDateWidget):
         self, attrs: Optional[Dict[str, Any]] = None, format: Optional[str] = None
     ) -> None:
         attrs = {
-            "class": "vDateField " + " ".join(INPUT_CLASSES),
+            "class": "vDateField " + " ".join(get_config()["INPUT_CLASSES"]),
             "size": "10",
             **(attrs or {}),
         }
@@ -333,7 +134,7 @@ class UnfoldAdminTimeWidget(AdminTimeWidget):
         self, attrs: Optional[Dict[str, Any]] = None, format: Optional[str] = None
     ) -> None:
         attrs = {
-            "class": "vTimeField " + " ".join(INPUT_CLASSES),
+            "class": "vTimeField " + " ".join(get_config()["INPUT_CLASSES"]),
             "size": "8",
             **(attrs or {}),
         }
@@ -347,7 +148,7 @@ class UnfoldAdminSingleTimeWidget(AdminTimeWidget):
         self, attrs: Optional[Dict[str, Any]] = None, format: Optional[str] = None
     ) -> None:
         attrs = {
-            "class": "vTimeField " + " ".join(INPUT_CLASSES),
+            "class": "vTimeField " + " ".join(get_config()["INPUT_CLASSES"]),
             "size": "8",
             **(attrs or {}),
         }
@@ -365,9 +166,9 @@ class UnfoldAdminTextareaWidget(AdminTextareaWidget):
         super().__init__(
             attrs={
                 "class": "vLargeTextField "
-                + " ".join(TEXTAREA_CLASSES)
+                + " ".join(get_config()["TEXTAREA_CLASSES"])
                 + " "
-                + " ".join(TEXTAREA_EXPANDABLE_CLASSES),
+                + " ".join(get_config()["TEXTAREA_EXPANDABLE_CLASSES"]),
                 **(attrs or {}),
             }
         )
@@ -419,17 +220,23 @@ class UnfoldAdminSplitDateTimeVerticalWidget(AdminSplitDateTime):
 
 class UnfoldAdminIntegerFieldWidget(AdminIntegerFieldWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__(attrs={"class": " ".join(INPUT_CLASSES), **(attrs or {})})
+        super().__init__(
+            attrs={"class": " ".join(get_config()["INPUT_CLASSES"]), **(attrs or {})}
+        )
 
 
 class UnfoldAdminDecimalFieldWidget(AdminIntegerFieldWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__(attrs={"class": " ".join(INPUT_CLASSES), **(attrs or {})})
+        super().__init__(
+            attrs={"class": " ".join(get_config()["INPUT_CLASSES"]), **(attrs or {})}
+        )
 
 
 class UnfoldAdminBigIntegerFieldWidget(AdminBigIntegerFieldWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__(attrs={"class": " ".join(INPUT_CLASSES), **(attrs or {})})
+        super().__init__(
+            attrs={"class": " ".join(get_config()["INPUT_CLASSES"]), **(attrs or {})}
+        )
 
 
 class UnfoldAdminNullBooleanSelectWidget(NullBooleanSelect):
@@ -441,7 +248,7 @@ class UnfoldAdminSelect(Select):
         if attrs is None:
             attrs = {}
 
-        attrs["class"] = " ".join(SELECT_CLASSES)
+        attrs["class"] = " ".join(get_config()["SELECT_CLASSES"])
         super().__init__(attrs, choices)
 
 
@@ -455,7 +262,7 @@ class UnfoldAdminRadioSelectWidget(AdminRadioSelect):
             radio_style = VERTICAL
 
         self.radio_style = radio_style
-        self.attrs = {"class": " ".join(RADIO_CLASSES)}
+        self.attrs = {"class": " ".join(get_config()["RADIO_CLASSES"])}
 
     def get_context(self, *args, **kwargs) -> Dict[str, Any]:
         context = super().get_context(*args, **kwargs)
@@ -493,7 +300,9 @@ class UnfoldBooleanWidget(CheckboxInput):
         return super().__init__(
             {
                 **(attrs or {}),
-                "class": " ".join(CHECKBOX_CLASSES + [attrs.get("class", "")]),
+                "class": " ".join(
+                    get_config()["CHECKBOX_CLASSES"] + [attrs.get("class", "")]
+                ),
             },
             check_test,
         )
@@ -504,5 +313,6 @@ class UnfoldBooleanSwitchWidget(CheckboxInput):
         self, attrs: Optional[Dict[str, Any]] = None, check_test: Callable = None
     ) -> None:
         return super().__init__(
-            attrs={"class": " ".join(SWITCH_CLASSES), **(attrs or {})}, check_test=None
+            attrs={"class": " ".join(get_config()["SWITCH_CLASSES"]), **(attrs or {})},
+            check_test=None,
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,18 +1,59 @@
-from django.conf import settings
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from unfold.settings import CONFIG_DEFAULTS, get_config
+from unfold.settings import (
+    BASE_CLASSES,
+    BASE_INPUT_CLASSES,
+    CHECKBOX_CLASSES,
+    CHECKBOX_LABEL_CLASSES,
+    COLOR_CLASSES,
+    CONFIG_DEFAULTS,
+    INPUT_CLASSES,
+    INPUT_CLASSES_READONLY,
+    LABEL_CLASSES,
+    PROSE_CLASSES,
+    RADIO_CLASSES,
+    SELECT_CLASSES,
+    SWITCH_CLASSES,
+    TEXTAREA_CLASSES,
+    TEXTAREA_EXPANDABLE_CLASSES,
+    get_config,
+)
 
 
 class ConfTestCase(SimpleTestCase):
+    expected_config = {
+        **CONFIG_DEFAULTS,
+        "LABEL_CLASSES": LABEL_CLASSES,
+        "CHECKBOX_LABEL_CLASSES": CHECKBOX_LABEL_CLASSES,
+        "BASE_CLASSES": BASE_CLASSES,
+        "BASE_INPUT_CLASSES": BASE_INPUT_CLASSES,
+        "INPUT_CLASSES": INPUT_CLASSES,
+        "COLOR_CLASSES": COLOR_CLASSES,
+        "INPUT_CLASSES_READONLY": INPUT_CLASSES_READONLY,
+        "TEXTAREA_CLASSES": TEXTAREA_CLASSES,
+        "TEXTAREA_EXPANDABLE_CLASSES": TEXTAREA_EXPANDABLE_CLASSES,
+        "SELECT_CLASSES": SELECT_CLASSES,
+        "PROSE_CLASSES": PROSE_CLASSES,
+        "CHECKBOX_CLASSES": CHECKBOX_CLASSES,
+        "RADIO_CLASSES": RADIO_CLASSES,
+        "SWITCH_CLASSES": SWITCH_CLASSES,
+    }
+
     def test_default_config(self):
-        self.assertDictEqual(get_config(), CONFIG_DEFAULTS)
+        self.assertDictEqual(get_config(), self.expected_config)
 
     def test_default_config_with_custom_settings_name(self):
-        self.assertDictEqual(get_config("CUSTOM_SETTINGS_NAME"), CONFIG_DEFAULTS)
+        # Assuming CUSTOM_SETTINGS_NAME will override some default settings.
+        # Need to define what CUSTOM_SETTINGS_NAME would change or add.
+        custom_settings = {"SITE_TITLE": "Custom Site Title"}
+        expected_custom_config = {**self.expected_config, **custom_settings}
+        with override_settings(UNFOLD=custom_settings):
+            self.assertDictEqual(get_config("UNFOLD"), expected_custom_config)
 
 
 class SettingsTestCase(SimpleTestCase):
     @override_settings(UNFOLD={**CONFIG_DEFAULTS, **{"SITE_TITLE": "Test site title"}})
     def test_extended_config(self):
-        self.assertEqual(settings.UNFOLD["SITE_TITLE"], "Test site title")
+        # This test ensures that changes made via the Django settings are reflected in get_config
+        config = get_config()
+        self.assertEqual(config["SITE_TITLE"], "Test site title")


### PR DESCRIPTION
- Move widget class variables to settings for centralized management.
- Update widgets to retrieve class attributes using the `get_config` function.
- Include new variables in the `get_config` function to support customization.
- Clean up imports in admin files and use `get_config` for widget classes.
- Using `get_config` on `forms.py` and `sites.py`
- Using `get_config` on filters and import_export `forms.py`

Usage: `settings.py`

```python
BASE_CLASSES = [
  'border',
  'bg-white',
  'font-medium',
  'rounded-md',
  'shadow-sm',
  'text-gray-500',
  'text-sm',
  'focus:ring',
  'focus:ring-primary-300',
  'focus:border-primary-600',
  'focus:outline-none',
  'group-[.errors]:border-red-600',
  'group-[.errors]:focus:ring-red-200',
  'dark:bg-gray-900',
  'dark:border-gray-700',
  'dark:text-gray-400',
  'dark:focus:border-primary-600',
  'dark:focus:ring-primary-700',
  'dark:focus:ring-opacity-50',
  'dark:group-[.errors]:border-red-500',
  'dark:group-[.errors]:focus:ring-red-600/40',
]

SELECT_CLASSES = [
  *BASE_CLASSES,
  'px-3',
  'py-2',
  'pr-8',
  'flex-grow',
  'max-w-2xl',
  'appearance-none',
  'truncate',
]


UNFOLD = {
  'SITE_TITLE': "Site name",
  'SITE_HEADER': None
  'SELECT_CLASSES': SELECT_CLASSES,
}
```
You can change classed by adding them to UNFOLD
#340 