### PR TITLE
fix: unable to set custom rows length for textarea widget

### DIFF
--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -360,7 +360,8 @@ class UnfoldAdminTextareaWidget(AdminTextareaWidget):
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
         attrs = attrs or {}
 
-        attrs.update({"rows": 2})
+        if "rows" not in attrs:
+            attrs.update({"rows": 2})
 
         super().__init__(
             attrs={


### PR DESCRIPTION
By default, textarea rows is set to 2 in UnfoldAdminTextareaWidget. But it is not possible to change this value, because it is systematicaly updated by the init function of this widget.