### PR TITLE
fix: object overwriting when using multiple charts

### DIFF
--- a/src/unfold/static/unfold/js/app.js
+++ b/src/unfold/static/unfold/js/app.js
@@ -207,7 +207,7 @@ const renderCharts = () => {
       new Chart(ctx, {
         type: type || "bar",
         data: JSON.parse(chart.dataset.value),
-        options: options ? JSON.parse(options) : DEFAULT_CHART_OPTIONS,
+        options: options ? JSON.parse(options) : Object.assign({}, DEFAULT_CHART_OPTIONS),
       })
     );
   });


### PR DESCRIPTION
This PR fixes an overwrite bug in the `DEFAULT_CHART_OPTIONS` as it was shared and mutated between chart instances resulting in a wrong rendering.

Before:
<img width="973" alt="image" src="https://github.com/unfoldadmin/django-unfold/assets/16452985/4a65ddc7-f4a6-4e4b-809c-6aad403841c6">

After:
<img width="982" alt="image" src="https://github.com/unfoldadmin/django-unfold/assets/16452985/c6269443-bad7-4e09-9bb6-11ab59069b18">
