### PR TITLE
docs: missing ClockedSchedule register

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,10 @@ class CrontabScheduleAdmin(ModelAdmin):
 @admin.register(SolarSchedule)
 class SolarScheduleAdmin(ModelAdmin):
     pass
+
+@admin.register(ClockedSchedule)
+class ClockedScheduleAdmin(ModelAdmin):
+    pass
 ```
 
 ### django-guardian


### PR DESCRIPTION
Hi there,

I noticed an omission in the `django_celery_beat` instructions.

It leads the copy/paste enthusiasts like me to an error where `ClockedSchedule` is unregistered
I figured I'd make a PR to fix it !

Thanks for this project, it's really cool. Keep it up ! 💯 