### PR TITLE
fix: ManyToMany Scrolling

### DIFF
--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -51,6 +51,7 @@ from .widgets import (
     CHECKBOX_LABEL_CLASSES,
     INPUT_CLASSES,
     LABEL_CLASSES,
+    MULTIPLE_SELECT_CLASSES,
     SELECT_CLASSES,
     UnfoldAdminBigIntegerFieldWidget,
     UnfoldAdminDecimalFieldWidget,
@@ -334,7 +335,7 @@ class ModelAdminMixin:
             return None
 
         if isinstance(form_field.widget, SelectMultiple):
-            form_field.widget.attrs["class"] = " ".join(SELECT_CLASSES)
+            form_field.widget.attrs["class"] = " ".join(MULTIPLE_SELECT_CLASSES)
 
         return form_field
 

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -108,6 +108,14 @@ SELECT_CLASSES = [
     "truncate",
 ]
 
+MULTIPLE_SELECT_CLASSES = [
+    *BASE_INPUT_CLASSES,
+    "pr-8",
+    "max-w-2xl",
+    "appearance-none",
+    "overflow-y-auto",
+]
+
 PROSE_CLASSES = [
     "font-normal",
     "prose-sm",


### PR DESCRIPTION
Problem:

- ManyToMany field in changeview is broken

![Screenshot 2024-05-10 at 1 33 24 PM](https://github.com/unfoldadmin/django-unfold/assets/7028968/ad82e710-8939-4bcb-97b8-456f3ff76909)

For issue #376 

Solution:

- Create a new class (MULTIPLE_SELECT_CLASSES)
  - remove the truncate class
  - add the overflow-y-auto

![image](https://github.com/unfoldadmin/django-unfold/assets/7028968/36270e20-eb5a-4db2-92eb-40d8a26098a0)
