### PR TITLE
feat: add site favicon to skeleton.html

### DIFF
--- a/src/unfold/templates/unfold/helpers/site_favicon.html
+++ b/src/unfold/templates/unfold/helpers/site_favicon.html
@@ -1,0 +1,11 @@
+{% load static %}
+
+{% comment %}
+    This snippet includes the favicon in the head of the HTML document.
+    It is used in the skeleton.html layout template.
+    You have to override the unfold/helpers/site_favicon.html in your project templates to use your favicons.
+
+    <link rel="apple-touch-icon" sizes="144x144" href="{% static 'favicon144.png' %}" />
+    <link rel="apple-touch-icon" sizes="72x72" href="{% static 'favicon72.png' %}" />
+    <link rel="icon" href="{% static 'favicon.png' %}" />
+{% endcomment %}

--- a/src/unfold/templates/unfold/layouts/skeleton.html
+++ b/src/unfold/templates/unfold/layouts/skeleton.html
@@ -16,6 +16,7 @@
 
 <head>
     <title>{% block title %}{% endblock %}</title>
+    {% include "unfold/helpers/site_favicon.html" %}
 
     <link href="{% static "unfold/fonts/inter/styles.css" %}" rel="stylesheet">
     <link href="{% static "unfold/fonts/material-symbols/styles.css" %}" rel="stylesheet">


### PR DESCRIPTION
Django Unfold doesn't have a favicon feature.
We had to override the whole `skeleton.html` template to add a favicon. (#206)

I have added a `site_favicon.html` file to the `unfold/helpers` directory, we can add all favicon types to the website.
Instead of overriding the `skeleton.html`, we will override just the `site_favicon.html`.

_PS: I added example favicon links as template comments._