### PR TITLE
fix: django-import-export unable to import

### DIFF
--- a/src/unfold/contrib/import_export/forms.py
+++ b/src/unfold/contrib/import_export/forms.py
@@ -1,15 +1,29 @@
-from import_export.forms import ImportExportFormBase as BaseImportExportFormBase
-from unfold.widgets import SELECT_CLASSES, UnfoldAdminFileFieldWidget
+from import_export.forms import ExportForm as ExportFormBase
+from import_export.forms import ImportForm as ImportFormBase
+from unfold.widgets import UnfoldAdminFileFieldWidget, UnfoldAdminSelectWidget
 
 
-class ImportForm(BaseImportExportFormBase):
+class ImportForm(ImportFormBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["resource"].widget = UnfoldAdminFileFieldWidget()
-        self.fields["format"].widget.attrs["class"] = " ".join(SELECT_CLASSES)
+        resource_widget = self.fields["resource"].widget
+        if len(resource_widget.choices) > 0:
+            self.fields["resource"].widget = UnfoldAdminSelectWidget(
+                attrs=resource_widget.attrs, choices=resource_widget.choices
+            )
+        else:
+            self.fields.pop("resource")
+        self.fields["import_file"].widget = UnfoldAdminFileFieldWidget()
+        format_widget = self.fields["format"].widget
+        self.fields["format"].widget = UnfoldAdminSelectWidget(
+            attrs=format_widget.attrs, choices=format_widget.choices
+        )
 
 
-class ExportForm(BaseImportExportFormBase):
+class ExportForm(ExportFormBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["format"].widget.attrs["class"] = " ".join(SELECT_CLASSES)
+        format_widget = self.fields["format"].widget
+        self.fields["format"].widget = UnfoldAdminSelectWidget(
+            attrs=format_widget.attrs, choices=format_widget.choices
+        )

--- a/src/unfold/contrib/import_export/templates/admin/import_export/import_form.html
+++ b/src/unfold/contrib/import_export/templates/admin/import_export/import_form.html
@@ -4,7 +4,7 @@
     <form action="" method="post" enctype="multipart/form-data">
         {% csrf_token %}
 
-        <p class="bg-blue-50 mb-8 text-blue-500 px-3 py-3 rounded-md text-sm dark:bg-blue-500/20 dark:border-blue-500/10">
+        <div class="bg-blue-50 mb-8 text-blue-500 px-3 py-3 rounded-md text-sm dark:bg-blue-500/20 dark:border-blue-500/10">
             {% trans "This importer will import the following fields: " %}
 
             {% if fields_list|length <= 1 %}
@@ -12,17 +12,19 @@
                     {{ fields_list.0.1|join:", " }}
                 </code>
             {% else %}
-                <dl>
+                <dl class="pt-1">
                     {% for resource, fields in fields_list %}
                         <dt>{{ resource }}</dt>
                         <dd><code>{{ fields|join:", " }}</code></dd>
                     {% endfor %}
                 </dl>
             {% endif %}
-        </p>
+        </div>
 
         <fieldset class="border border-gray-200 mb-8 rounded-md pt-3 px-3 shadow-sm dark:border-gray-800">
         {% include "unfold/helpers/field.html" with field=form.resource %}
+
+        {% include "unfold/helpers/field.html" with field=form.import_file %}
 
         {% include "unfold/helpers/field.html" with field=form.format %}
         </fieldset>


### PR DESCRIPTION
## Issue
Import action is broken per changes from #398 

Resource was inferred as the file field but it's a different field on its own. Current issue can also be observed on the deployed [unfoldadmin/formula](https://github.com/unfoldadmin/formula)
The actual file is never passed back to import-export since the expected input_file field is missing.

## Changes
Reverting partial changes from #398 while cleaning up the formatting a touch to manage multiple resources

Single Resource View:
<img width="980" alt="Screenshot 2024-05-21 at 3 44 50 PM" src="https://github.com/unfoldadmin/django-unfold/assets/7028968/dafc2b35-c1a0-47a8-80f7-c55b4b09239b">

Multiple Resource View:
<img width="768" alt="Screenshot 2024-05-21 at 3 45 05 PM" src="https://github.com/unfoldadmin/django-unfold/assets/7028968/2514051b-3c58-4ee0-83bd-183cf30f0c78">


## Tests
Tested locally with:
django-unfold@0.24
django@5
django-import-export@4.0.3

I didn't go too deep in the export action and how resources might play a part there since it was functional and not completely broken.