### PR TITLE
Fix/add language dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ UNFOLD = {
     "SITE_SYMBOL": "speed",  # symbol from icon set
     "SHOW_HISTORY": True, # show/hide "History" button, default: True
     "SHOW_VIEW_ON_SITE": True, # show/hide "View on site" button, default: True
+    "USE_MULTILANGUAGE": True, # show/hide "Dropdown for language" dropdown, default: False
     "ENVIRONMENT": "sample_app.environment_callback",
     "DASHBOARD_CALLBACK": "sample_app.dashboard_callback",
     "THEME": "dark", # Force theme: "dark" or "light". Will disable theme switcher

--- a/src/unfold/settings.py
+++ b/src/unfold/settings.py
@@ -9,6 +9,7 @@ CONFIG_DEFAULTS = {
     "SITE_LOGO": None,
     "SHOW_HISTORY": True,
     "SHOW_VIEW_ON_SITE": True,
+    "USE_MULTILANGUAGE": False,
     "COLORS": {
         "primary": {
             "50": "250 245 255",

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -123,8 +123,7 @@ class UnfoldAdminSite(AdminSite):
             **(extra_context or {}),
         }
 
-        dashboard_callback = get_config(self.settings_name)[
-            "DASHBOARD_CALLBACK"]
+        dashboard_callback = get_config(self.settings_name)["DASHBOARD_CALLBACK"]
 
         if isinstance(dashboard_callback, str):
             context = import_string(dashboard_callback)(request, context)
@@ -187,8 +186,7 @@ class UnfoldAdminSite(AdminSite):
         )
 
         redirect_field_name = self._get_value(
-            get_config(self.settings_name)["LOGIN"].get(
-                "redirect_after"), request
+            get_config(self.settings_name)["LOGIN"].get("redirect_after"), request
         )
 
         if image not in EMPTY_VALUES:
@@ -210,8 +208,7 @@ class UnfoldAdminSite(AdminSite):
 
         from .forms import AdminOwnPasswordChangeForm
 
-        url = reverse(f"{self.name}:password_change_done",
-                      current_app=self.name)
+        url = reverse(f"{self.name}:password_change_done", current_app=self.name)
         defaults = {
             "form_class": AdminOwnPasswordChangeForm,
             "success_url": url,
@@ -223,8 +220,7 @@ class UnfoldAdminSite(AdminSite):
         return PasswordChangeView.as_view(**defaults)(request)
 
     def get_sidebar_list(self, request: HttpRequest) -> List[Dict[str, Any]]:
-        navigation = get_config(self.settings_name)[
-            "SIDEBAR"].get("navigation", [])
+        navigation = get_config(self.settings_name)["SIDEBAR"].get("navigation", [])
         results = []
 
         def _get_is_active(link: str) -> bool:
@@ -369,7 +365,6 @@ class UnfoldAdminSite(AdminSite):
                 if value[0] != "#":
                     continue
 
-                colors[name][weight] = " ".join(
-                    str(item) for item in hex_to_rgb(value))
+                colors[name][weight] = " ".join(str(item) for item in hex_to_rgb(value))
 
         return colors

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -70,6 +70,9 @@ class UnfoldAdminSite(AdminSite):
                 "show_view_on_site": get_config(self.settings_name)[
                     "SHOW_VIEW_ON_SITE"
                 ],
+                "use_multilanguage": get_config(self.settings_name)[
+                    "USE_MULTILANGUAGE"
+                ],
                 "colors": self._process_colors(
                     get_config(self.settings_name)["COLORS"]
                 ),
@@ -120,7 +123,8 @@ class UnfoldAdminSite(AdminSite):
             **(extra_context or {}),
         }
 
-        dashboard_callback = get_config(self.settings_name)["DASHBOARD_CALLBACK"]
+        dashboard_callback = get_config(self.settings_name)[
+            "DASHBOARD_CALLBACK"]
 
         if isinstance(dashboard_callback, str):
             context = import_string(dashboard_callback)(request, context)
@@ -183,7 +187,8 @@ class UnfoldAdminSite(AdminSite):
         )
 
         redirect_field_name = self._get_value(
-            get_config(self.settings_name)["LOGIN"].get("redirect_after"), request
+            get_config(self.settings_name)["LOGIN"].get(
+                "redirect_after"), request
         )
 
         if image not in EMPTY_VALUES:
@@ -205,7 +210,8 @@ class UnfoldAdminSite(AdminSite):
 
         from .forms import AdminOwnPasswordChangeForm
 
-        url = reverse(f"{self.name}:password_change_done", current_app=self.name)
+        url = reverse(f"{self.name}:password_change_done",
+                      current_app=self.name)
         defaults = {
             "form_class": AdminOwnPasswordChangeForm,
             "success_url": url,
@@ -217,7 +223,8 @@ class UnfoldAdminSite(AdminSite):
         return PasswordChangeView.as_view(**defaults)(request)
 
     def get_sidebar_list(self, request: HttpRequest) -> List[Dict[str, Any]]:
-        navigation = get_config(self.settings_name)["SIDEBAR"].get("navigation", [])
+        navigation = get_config(self.settings_name)[
+            "SIDEBAR"].get("navigation", [])
         results = []
 
         def _get_is_active(link: str) -> bool:
@@ -362,6 +369,7 @@ class UnfoldAdminSite(AdminSite):
                 if value[0] != "#":
                     continue
 
-                colors[name][weight] = " ".join(str(item) for item in hex_to_rgb(value))
+                colors[name][weight] = " ".join(
+                    str(item) for item in hex_to_rgb(value))
 
         return colors

--- a/src/unfold/templates/unfold/helpers/language_switch.html
+++ b/src/unfold/templates/unfold/helpers/language_switch.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+
+<form id="language-form" action="{% url 'set_language' %}" method="post">{% csrf_token %}
+    <input name="next" type="hidden" value="{{ request.path }}">
+    <select name="language" 
+            class="border bg-white font-medium rounded-md shadow-sm text-gray-500 text-sm focus:ring focus:ring-primary-300 focus:border-primary-600 focus:outline-none group-[.errors]:border-red-600 group-[.errors]:focus:ring-red-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-400 dark:focus:border-primary-600 dark:focus:ring-primary-700 dark:focus:ring-opacity-50 dark:group-[.errors]:border-red-500 dark:group-[.errors]:focus:ring-red-600/40 px-3 py-2 w-full pr-8 max-w-2xl appearance-none truncate w-72"
+            onchange="document.getElementById('language-form').submit();">
+        {% get_current_language as LANGUAGE_CODE %}
+        {% get_available_languages as LANGUAGES %}
+        {% get_language_info_list for LANGUAGES as languages %}
+        {% for language in languages %}
+            <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
+                {{ language.name_local }} ({{ language.code }})
+            </option>
+        {% endfor %}
+    </select>
+</form>

--- a/src/unfold/templates/unfold/helpers/language_switch.html
+++ b/src/unfold/templates/unfold/helpers/language_switch.html
@@ -2,7 +2,7 @@
 
 <form id="language-form" action="{% url 'set_language' %}" method="post">{% csrf_token %}
     <input name="next" type="hidden" value="{{ request.path }}">
-    <select name="language" 
+    <select name="language"
             class="border bg-white font-medium rounded-md shadow-sm text-gray-500 text-sm focus:ring focus:ring-primary-300 focus:border-primary-600 focus:outline-none group-[.errors]:border-red-600 group-[.errors]:focus:ring-red-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-400 dark:focus:border-primary-600 dark:focus:ring-primary-700 dark:focus:ring-opacity-50 dark:group-[.errors]:border-red-500 dark:group-[.errors]:focus:ring-red-600/40 px-3 py-2 w-full pr-8 max-w-2xl appearance-none truncate w-72"
             onchange="document.getElementById('language-form').submit();">
         {% get_current_language as LANGUAGE_CODE %}

--- a/src/unfold/templates/unfold/helpers/userlinks.html
+++ b/src/unfold/templates/unfold/helpers/userlinks.html
@@ -12,6 +12,10 @@
             {% endif %}
 
             {% include "unfold/helpers/account_links.html" %}
+            
+            {% if use_multilanguage %}
+                {% include "unfold/helpers/language_switch.html" %}
+            {% endif %}
         </div>
     </div>
 

--- a/src/unfold/templates/unfold/helpers/userlinks.html
+++ b/src/unfold/templates/unfold/helpers/userlinks.html
@@ -12,7 +12,7 @@
             {% endif %}
 
             {% include "unfold/helpers/account_links.html" %}
-            
+
             {% if use_multilanguage %}
                 {% include "unfold/helpers/language_switch.html" %}
             {% endif %}


### PR DESCRIPTION
updated files:

- src/unfold/settings.py
- src/unfold/sites.py
- src/unfold/templates/unfold/helpers/language_switch.html
- src/unfold/templates/unfold/helpers/userlinks.html
- README.md

Description of changes:
I've added a new option for this theme. I added a dropdown, next to the User icon, for changing languages. It'll help Django developers to implement multilanguage much more easily and visually.

They have to know about [How Django discovers language preference](https://docs.djangoproject.com/en/5.0/topics/i18n/translation/#how-django-discovers-language-preference).

Images:
<img width="362" alt="Screenshot 1403-03-27 at 20 27 33" src="https://github.com/unfoldadmin/django-unfold/assets/45732355/91b1642b-03fc-47e1-850b-1b4a52452777">
<img width="152" alt="Screenshot 1403-03-27 at 20 27 46" src="https://github.com/unfoldadmin/django-unfold/assets/45732355/a551a3bb-99ce-4425-a0f6-8cb056f67817">
