### PR TITLE
Fix: Textarea scroll

### DIFF
--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -90,7 +90,7 @@ TEXTAREA_CLASSES = [
     "max-w-4xl",
     "appearance-none",
     "expandable",
-    "overflow-hidden",
+    "overflow-auto",
     "transition",
     "transition-height",
     "duration-75",


### PR DESCRIPTION
### Fix: Make Textarea Scrollable When Content Exceeds Height
**Summary**
This pull request addresses an issue where the textarea was not scrollable via the mouse when the content exceeded its current height. The issue was caused by the overflow-hidden class, which prevented scrolling. This fix replaces overflow-hidden with overflow-auto, allowing the textarea to be scrollable.

**Description**
**Issue:** When the content inside a textarea exceeded its defined height, users were unable to scroll through the content using the mouse.
**Solution:** Replaced overflow-hidden with overflow-auto on the textarea element. This change allows the content to be scrollable when it exceeds the textarea's height.
**Changes**
Modified CSS class for textarea from overflow-hidden to overflow-auto.