### PR TITLE
feat: implement dynamic favicon inclusion using site_favicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ from django.utils.translation import gettext_lazy as _
 
 UNFOLD = {
     "SITE_TITLE": None,
+    "SITE_FAVICONS": {
+        "SITE_FAVICON_16": lambda request: static("favicon-16x16.png"),
+        "SITE_FAVICON_32": lambda request: static("favicon-32x32.png"),
+        "SITE_FAVICON_48": lambda request: static("favicon-48x48.png"),
+        "SITE_FAVICON_96": lambda request: static("favicon-96x96.png"),
+        "APPLE_ICON_57": lambda request: static("apple-icon-57x57.png"),
+        "APPLE_ICON_60": lambda request: static("apple-icon-60x60.png"),
+        "APPLE_ICON_72": lambda request: static("apple-icon-72x72.png"),
+        "APPLE_ICON_76": lambda request: static("apple-icon-76x76.png"),
+        "APPLE_ICON_114": lambda request: static("apple-icon-114x114.png"),
+        "APPLE_ICON_120": lambda request: static("apple-icon-120x120.png"),
+        "APPLE_ICON_144": lambda request: static("apple-icon-144x144.png"),
+        "APPLE_ICON_152": **lambda** request: static("apple-icon-152x152.png"),
+        "APPLE_ICON_180": lambda request: static("apple-icon-180x180.png"),
+        "MS_TILE_144": lambda request: static("ms-icon-144x144.png"),
+        "ANDROID_ICON_192": lambda request: static("android-icon-192x192.png"),
+        "FAVICON_ICO": lambda request: static("favicon.ico)"
+    },
     "SITE_HEADER": None,
     "SITE_URL": "/",
     # "SITE_ICON": lambda request: static("icon.svg"),  # both modes, optimise for 32px height

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ UNFOLD = {
         "APPLE_ICON_114": lambda request: static("apple-icon-114x114.png"),
         "APPLE_ICON_120": lambda request: static("apple-icon-120x120.png"),
         "APPLE_ICON_144": lambda request: static("apple-icon-144x144.png"),
-        "APPLE_ICON_152": **lambda** request: static("apple-icon-152x152.png"),
+        "APPLE_ICON_152": lambda request: static("apple-icon-152x152.png"),
         "APPLE_ICON_180": lambda request: static("apple-icon-180x180.png"),
         "MS_TILE_144": lambda request: static("ms-icon-144x144.png"),
         "ANDROID_ICON_192": lambda request: static("android-icon-192x192.png"),

--- a/src/unfold/settings.py
+++ b/src/unfold/settings.py
@@ -7,6 +7,7 @@ CONFIG_DEFAULTS = {
     "SITE_ICON": None,
     "SITE_SYMBOL": None,
     "SITE_LOGO": None,
+    "SITE_FAVICONS": None,
     "SHOW_HISTORY": True,
     "SHOW_VIEW_ON_SITE": True,
     "COLORS": {

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -66,6 +66,9 @@ class UnfoldAdminSite(AdminSite):
                 "site_symbol": self._get_value(
                     get_config(self.settings_name)["SITE_SYMBOL"], request
                 ),
+                "site_favicons": self._get_value(
+                    get_config(self.settings_name)["SITE_FAVICONS"], request
+                ),
                 "show_history": get_config(self.settings_name)["SHOW_HISTORY"],
                 "show_view_on_site": get_config(self.settings_name)[
                     "SHOW_VIEW_ON_SITE"

--- a/src/unfold/templates/unfold/helpers/favicon.html
+++ b/src/unfold/templates/unfold/helpers/favicon.html
@@ -1,0 +1,62 @@
+{% load i18n %}
+{% if site_favicons %}
+    <!-- Favicon for all browsers -->
+    {% if site_favicons.favicon_16x16 %}
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ site_favicons.favicon_16x16 }}">
+    {% endif %}
+    {% if site_favicons.favicon_32x32 %}
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ site_favicons.favicon_32x32 }}">
+    {% endif %}
+    {% if site_favicons.favicon_48x48 %}
+        <link rel="icon" type="image/png" sizes="48x48" href="{{ site_favicons.favicon_48x48 }}">
+    {% endif %}
+    {% if site_favicons.favicon_96x96 %}
+        <link rel="icon" type="image/png" sizes="96x96" href="{{ site_favicons.favicon_96x96 }}">
+    {% endif %}
+
+    <!-- Apple Touch Icon -->
+    {% if site_favicons.apple_icon_57 %}
+        <link rel="apple-touch-icon" sizes="57x57" href="{{ site_favicons.apple_icon_57 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_60 %}
+        <link rel="apple-touch-icon" sizes="60x60" href="{{ site_favicons.apple_icon_60 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_72 %}
+        <link rel="apple-touch-icon" sizes="72x72" href="{{ site_favicons.apple_icon_72 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_76 %}
+        <link rel="apple-touch-icon" sizes="76x76" href="{{ site_favicons.apple_icon_76 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_114 %}
+        <link rel="apple-touch-icon" sizes="114x114" href="{{ site_favicons.apple_icon_114 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_120 %}
+        <link rel="apple-touch-icon" sizes="120x120" href="{{ site_favicons.apple_icon_120 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_144 %}
+        <link rel="apple-touch-icon" sizes="144x144" href="{{ site_favicons.apple_icon_144 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_152 %}
+        <link rel="apple-touch-icon" sizes="152x152" href="{{ site_favicons.apple_icon_152 }}">
+    {% endif %}
+    {% if site_favicons.apple_icon_180 %}
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ site_favicons.apple_icon_180 }}">
+    {% endif %}
+
+    <!-- Windows 8 Tile Icon -->
+    {% if site_favicons.ms_tile_144 %}
+        <meta name="msapplication-TileColor" content="#ffffff">
+        <meta name="msapplication-TileImage" content="{{ site_favicons.ms_tile_144 }}">
+    {% endif %}
+
+    <!-- Android Chrome Icons -->
+    {% if site_favicons.android_icon_192 %}
+        <link rel="icon" type="image/png" sizes="192x192" href="{{ site_favicons.android_icon_192 }}">
+    {% endif %}
+
+    <!-- Favicon for IE -->
+    {% if site_favicons.favicon_ico %}
+        <link rel="icon" type="image/x-icon" href="{{ site_favicons.favicon_ico }}">
+        <link rel="shortcut icon" type="image/x-icon" href="{{ site_favicons.favicon_ico }}">
+    {% endif %}
+{% endif %}

--- a/src/unfold/templates/unfold/helpers/favicon.html
+++ b/src/unfold/templates/unfold/helpers/favicon.html
@@ -1,4 +1,3 @@
-{% load i18n %}
 {% if site_favicons %}
     <!-- Favicon for all browsers -->
     {% if site_favicons.favicon_16x16 %}

--- a/src/unfold/templates/unfold/layouts/skeleton.html
+++ b/src/unfold/templates/unfold/layouts/skeleton.html
@@ -17,6 +17,8 @@
 <head>
     <title>{% block title %}{% endblock %}</title>
 
+    {% include "unfold/helpers/favicon.html" %}
+
     <link href="{% static "unfold/fonts/inter/styles.css" %}" rel="stylesheet">
     <link href="{% static "unfold/fonts/material-symbols/styles.css" %}" rel="stylesheet">
 


### PR DESCRIPTION
Hello,

This PR introduces a feature to enhance favicon management by dynamically including favicons in the HTML head section through the site_favicons dictionary. This method ensures that only the existing favicon files are referenced, which enhances site efficiency and prevents broken links.

Changes:
- Added logic to verify the presence of various favicon sizes and types.
- Modified the HTML template to dynamically include favicons from the site_favicons dictionary.
- Supported favicon dimensions: 16x16, 32x32, 48x48, 96x96.
- Supported Apple touch icon dimensions: 57x57, 60x60, 72x72, 76x76, 114x114, 120x120, 144x144, 152x152, 180x180.
- Added meta tags for Windows tile icons and Android Chrome icons.

These changes enhance cross-browser and device compatibility while streamlining the favicon loading process.

The `site_favicons` dictionary is optional and can be configured as follows:

```python
"SITE_FAVICONS": {
    "SITE_FAVICON_16": lambda request: static("favicon-16x16.png"),
    "SITE_FAVICON_32": lambda request: static("favicon-32x32.png"),
    "SITE_FAVICON_48": lambda request: static("favicon-48x48.png"),
    "SITE_FAVICON_96": lambda request: static("favicon-96x96.png"),
    "APPLE_ICON_57": lambda request: static("apple-icon-57x57.png"),
    "APPLE_ICON_60": lambda request: static("apple-icon-60x60.png"),
    "APPLE_ICON_72": lambda request: static("apple-icon-72x72.png"),
    "APPLE_ICON_76": lambda request: static("apple-icon-76x76.png"),
    "APPLE_ICON_114": lambda request: static("apple-icon-114x114.png"),
    "APPLE_ICON_120": lambda request: static("apple-icon-120x120.png"),
    "APPLE_ICON_144": lambda request: static("apple-icon-144x144.png"),
    "APPLE_ICON_152": lambda request: static("apple-icon-152x152.png"),
    "APPLE_ICON_180": lambda request: static("apple-icon-180x180.png"),
    "MS_TILE_144": lambda request: static("ms-icon-144x144.png"),
    "ANDROID_ICON_192": lambda request: static("android-icon-192x192.png"),
    "FAVICON_ICO": lambda request: static("favicon.ico")
}
