### PR TITLE
fix: double attribute "id" for file field

### DIFF
--- a/src/unfold/templates/unfold/widgets/clearable_file_input.html
+++ b/src/unfold/templates/unfold/widgets/clearable_file_input.html
@@ -25,7 +25,7 @@
 
     <div class="flex flex-none items-center leading-none self-stretch">
         <div class="hidden">
-            <input id="{{ widget.name }}" type="{{ widget.type }}" name="{{ widget.name }}" {% include "django/forms/widgets/attrs.html" %} />
+            <input type="{{ widget.type }}" name="{{ widget.name }}" {% include "django/forms/widgets/attrs.html" %} />
         </div>
 
         {% if widget.is_initial %}
@@ -34,7 +34,7 @@
             </a>
         {% endif %}
 
-        <label for="{{ widget.name }}" class="cursor-pointer text-gray-400 px-3 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200">
+        <label for="{{ widget.attrs.id }}" class="cursor-pointer text-gray-400 px-3 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200">
             <span class="material-symbols-outlined">upload</span>
         </label>
     </div>

--- a/src/unfold/templates/unfold/widgets/clearable_file_input_small.html
+++ b/src/unfold/templates/unfold/widgets/clearable_file_input_small.html
@@ -17,9 +17,9 @@
         <input type="text" value="{% if widget.value %}{{ widget.value.url }}{% else %}{% trans 'Choose file to upload' %}{% endif %}" disabled class="bg-white flex-grow font-medium px-3 py-2 text-ellipsis dark:bg-gray-900 {% if widget.value %}text-gray-500 dark:text-gray-300{% else %}text-gray-300 dark:text-gray-300{% endif %}">
 
         <div class="flex flex-none items-center leading-none self-stretch">
-            <input id="{{ widget.name }}" type="{{ widget.type }}" name="{{ widget.name }}" class="{{ widget.file_input_class }}" {% include "django/forms/widgets/attrs.html" %} />
+            <input type="{{ widget.type }}" name="{{ widget.name }}" class="{{ widget.file_input_class }}" {% include "django/forms/widgets/attrs.html" %} />
 
-            <label for="{{ widget.name }}" class="cursor-pointer text-gray-400 px-3 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200">
+            <label for="{{ widget.attrs.id }}" class="cursor-pointer text-gray-400 px-3 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200">
                 <span class="material-symbols-outlined">file_upload</span>
             </label>
         </div>


### PR DESCRIPTION
See: #581

Fixed code:

```html
    <div class="flex flex-none items-center leading-none self-stretch">
        <div class="hidden">
            <input type="file" name="image"  accept="image/*" id="id_image" />
        </div>

        <label for="id_image" class="cursor-pointer text-gray-400 px-3 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200">
            <span class="material-symbols-outlined">upload</span>
        </label>
    </div>
```