### PR TITLE
docs: add Chart.js credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,3 +1356,4 @@ The container has already a node preinstalled so it is possible to compile a new
 - [Material Icons](https://fonts.google.com/icons) - Icons from Google Fonts
 - [Trix](https://trix-editor.org/) - WYSIWYG editor
 - [Alpine.js](https://alpinejs.dev/) - JavaScript interactions
+- [Chart.js](https://github.com/chartjs/Chart.js/) - Chart components


### PR DESCRIPTION
Took me a while to figure out what is used for Charts since there was no reference.
I've added the info to the README.md in this PR.