### PR TITLE
fix:filter datetime invalid

### DIFF
--- a/src/unfold/contrib/filters/admin.py
+++ b/src/unfold/contrib/filters/admin.py
@@ -548,6 +548,7 @@ class RangeDateTimeFilter(admin.FieldListFilter):
         time_value_to = self.used_parameters.get(self.parameter_name + "_to_1", None)
 
         if date_value_from not in EMPTY_VALUES and time_value_from not in EMPTY_VALUES:
+            date_value_from = date_value_from.replace("/", "-")
             filters.update(
                 {
                     f"{self.parameter_name}__gte": parse_datetime(
@@ -557,6 +558,7 @@ class RangeDateTimeFilter(admin.FieldListFilter):
             )
 
         if date_value_to not in EMPTY_VALUES and time_value_to not in EMPTY_VALUES:
+            date_value_to = date_value_to.replace("/", "-")
             filters.update(
                 {
                     f"{self.parameter_name}__lte": parse_datetime(

--- a/src/unfold/templates/unfold/widgets/split_datetime_vertical.html
+++ b/src/unfold/templates/unfold/widgets/split_datetime_vertical.html
@@ -1,4 +1,4 @@
-<div class="datetime flex flex-col max-w-2xl">
+<div class="datetime flex flex-col max-w-2xl w-full">
     <div class="flex flex-col flex-wrap mb-2">
         {% if date_label %}
             <div class="mb-2 text-gray-500 text-sm dark:text-gray-200">
@@ -7,7 +7,7 @@
         {% endif %}
 
         {% with widget=widget.subwidgets.0 %}
-            <div class="flex flex-row">
+            <div class="flex flex-col relative">
                 {% include widget.template_name %}
             </div>
         {% endwith %}
@@ -21,7 +21,7 @@
         {% endif %}
 
         {% with widget=widget.subwidgets.1 %}
-            <div class="flex flex-row">
+            <div class="flex flex-col relative">
                 {% include widget.template_name %}
             </div>
         {% endwith %}


### PR DESCRIPTION
1、The filter date time format '% Y/% m/% dT% H:% m' is invalid. Conversion to '% Y -% m -% dT% H:% m' is available
2、Date display, date does not display shortcut buttons