### PR TITLE
feat: datetimeshortcuts support added (#660)

### DIFF
--- a/src/unfold/templates/unfold/widgets/split_datetime_vertical.html
+++ b/src/unfold/templates/unfold/widgets/split_datetime_vertical.html
@@ -1,27 +1,27 @@
-<div class="datetime flex flex-col max-w-2xl">
-    <div class="flex flex-col flex-wrap mb-2">
+<div class="datetime flex flex-col gap-2 max-w-2xl lg:group-[.field-row]:items-center lg:group-[.field-tabular]:flex-col lg:group-[.field-tabular]:items-center">
+    <div class="basis-1/2 flex flex-col lg:w-1/2 md:mt-0 lg:group-[.field-row]:flex-col group-[.field-row]:gap-2 lg:group-[.field-tabular]:flex-col group-[.field-tabular]:gap-2">
         {% if date_label %}
-            <div class="mb-2">
+            <div class="font-medium mb-2 group-[.field-row]:mb-0 group-[.field-row]:flex group-[.field-row]:items-center group-[.field-tabular]:mb-0 group-[.field-tabular]:flex group-[.field-tabular]:items-center">
                 {{ date_label }}
             </div>
         {% endif %}
 
         {% with widget=widget.subwidgets.0 %}
-            <div class="flex flex-row">
+            <div class="flex flex-col min-w-52 relative group-[.field-row]:flex-grow group-[.field-tabular]:flex-grow">
                 {% include widget.template_name %}
             </div>
         {% endwith %}
     </div>
 
-    <div class="flex flex-col flex-wrap mt-3 md:mt-0">
+    <div class="basis-1/2 flex flex-col lg:w-1/2 md:mt-0 lg:group-[.field-row]:flex-col group-[.field-row]:gap-2 lg:group-[.field-tabular]:flex-col group-[.field-tabular]:gap-2">
         {% if time_label %}
-            <div class="mb-2">
+            <div class="font-medium mb-2 group-[.field-row]:mb-0 group-[.field-row]:flex group-[.field-row]:items-center group-[.field-tabular]:mb-0 group-[.field-tabular]:flex group-[.field-tabular]:items-center">
                 {{ time_label }}
             </div>
         {% endif %}
 
         {% with widget=widget.subwidgets.1 %}
-            <div class="flex flex-row">
+            <div class="flex flex-col min-w-52 relative group-[.field-row]:flex-grow group-[.field-tabular]:flex-grow">
                 {% include widget.template_name %}
             </div>
         {% endwith %}

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -408,6 +408,16 @@ class UnfoldAdminExpandableTextareaWidget(AdminTextareaWidget):
 class UnfoldAdminSplitDateTimeWidget(AdminSplitDateTime):
     template_name = "unfold/widgets/split_datetime.html"
 
+    class Media:
+        js = (
+            "/admin/jsi18n/",
+            "/static/admin/js/vendor/jquery/jquery.js",
+            "/static/admin/js/calendar.js",
+            "/static/admin/js/jquery.init.js",
+            "/static/admin/js/admin/DateTimeShortcuts.js",
+            "/static/admin/js/core.js"
+        )
+
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
         widgets = [UnfoldAdminDateWidget, UnfoldAdminTimeWidget]
         MultiWidget.__init__(self, widgets, attrs)
@@ -415,6 +425,16 @@ class UnfoldAdminSplitDateTimeWidget(AdminSplitDateTime):
 
 class UnfoldAdminSplitDateTimeVerticalWidget(AdminSplitDateTime):
     template_name = "unfold/widgets/split_datetime_vertical.html"
+
+    class Media:
+        js = (
+            "/admin/jsi18n/",
+            "/static/admin/js/vendor/jquery/jquery.js",
+            "/static/admin/js/calendar.js",
+            "/static/admin/js/jquery.init.js",
+            "/static/admin/js/admin/DateTimeShortcuts.js",
+            "/static/admin/js/core.js"
+        )
 
     def __init__(
         self,

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -415,7 +415,7 @@ class UnfoldAdminSplitDateTimeWidget(AdminSplitDateTime):
             "/static/admin/js/calendar.js",
             "/static/admin/js/jquery.init.js",
             "/static/admin/js/admin/DateTimeShortcuts.js",
-            "/static/admin/js/core.js"
+            "/static/admin/js/core.js",
         )
 
     def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
@@ -433,7 +433,7 @@ class UnfoldAdminSplitDateTimeVerticalWidget(AdminSplitDateTime):
             "/static/admin/js/calendar.js",
             "/static/admin/js/jquery.init.js",
             "/static/admin/js/admin/DateTimeShortcuts.js",
-            "/static/admin/js/core.js"
+            "/static/admin/js/core.js",
         )
 
     def __init__(


### PR DESCRIPTION
Feat issue: https://github.com/unfoldadmin/django-unfold/issues/660

This fork adds datetimeshortcuts support to the UnfoldAdminSplitDateTimeWidget and UnfoldAdminSplitDateTimeVerticalWidget widgets and fix UnfoldAdminSplitDateTimeVerticalWidget styles . The console displays an error saying gettext is not defined, but everything works fine.

screenshot:
![Screenshot_20240806_171042](https://github.com/user-attachments/assets/4e547963-adec-4530-9ac2-210df0635219)

I think this error is an import order issue. i will fix this warning soon.