### PR TITLE
Adding GeneratedField to supported types for RangeNumericFilter

### DIFF
--- a/src/unfold/contrib/filters/admin.py
+++ b/src/unfold/contrib/filters/admin.py
@@ -14,6 +14,7 @@ from django.db.models.fields import (
     FloatField,
     IntegerField,
 )
+from django.db.models.fields.generated import GeneratedField
 from django.forms import ValidationError
 from django.http import HttpRequest
 from django.utils.dateparse import parse_datetime
@@ -341,7 +342,9 @@ class RangeNumericFilter(RangeNumericMixin, admin.FieldListFilter):
         field_path: str,
     ) -> None:
         super().__init__(field, request, params, model, model_admin, field_path)
-        if not isinstance(field, (DecimalField, IntegerField, FloatField, AutoField)):
+        if not isinstance(
+            field, (DecimalField, IntegerField, FloatField, AutoField, GeneratedField)
+        ):
             raise TypeError(
                 f"Class {type(self.field)} is not supported for {self.__class__.__name__}."
             )


### PR DESCRIPTION
I have a use case where I wish to have a RangeNumericFilter for a GeneratedField.
This was not allowed until now. This PR is to allow this configuration.

I had not added any extra validations to check whether the actual value of the GeneratedField is numeric, as I don't think this should be done by unfold. Let me know if you think otherwise.