### PR TITLE
Move changeform templates outside form tags

### DIFF
--- a/src/unfold/templates/admin/change_form.html
+++ b/src/unfold/templates/admin/change_form.html
@@ -61,12 +61,12 @@
     <div id="content-main">
         {% block form_before %}{% endblock %}
 
+        {% if adminform.model_admin.change_form_before_template %}
+            {% include adminform.model_admin.change_form_before_template %}
+        {% endif %}
+
         <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}{% if form_url %}action="{{ form_url }}" {% endif %}method="post" id="{{ opts.model_name }}_form" {% if adminform.model_admin.warn_unsaved_form %}class="warn-unsaved-form"{% endif %} novalidate>
             {% csrf_token %}
-
-            {% if adminform.model_admin.change_form_before_template %}
-                {% include adminform.model_admin.change_form_before_template %}
-            {% endif %}
 
             {% block form_top %}{% endblock %}
 
@@ -102,10 +102,6 @@
 
                 {% block after_related_objects %}{% endblock %}
 
-                {% if adminform.model_admin.change_form_after_template %}
-                    {% include adminform.model_admin.change_form_after_template %}
-                {% endif %}
-
                 {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
 
                 {% block admin_change_form_document_ready %}
@@ -115,6 +111,10 @@
                 {% prepopulated_fields_js %}
             </div>
         </form>
+
+        {% if adminform.model_admin.change_form_after_template %}
+            {% include adminform.model_admin.change_form_after_template %}
+        {% endif %}
 
         {% block form_after %}{% endblock %}
     </div>


### PR DESCRIPTION
Move `change_form_before_template` and `change_form_after_template` outside the form tags in `change_form.html`.

Closes: #887

* **Template Changes:**
  - Include `change_form_before_template` outside the form tags.
  - Include `change_form_after_template` outside the form tags.
  - Remove `change_form_before_template` from inside the form tags.
  - Remove `change_form_after_template` from inside the form tags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/unfoldadmin/django-unfold/pull/888?shareId=d9dcb485-e968-4781-a8d2-f345d3ba27ec).