### PR TITLE
docs: cohort correct file path

### DIFF
--- a/docs/components/cohort.md
+++ b/docs/components/cohort.md
@@ -16,7 +16,7 @@ In template you can use the default implementation of the cohort component by us
 ```html
 {% load unfold %}
 
-{% component "unfold/components/cohort.html" with component_class="MyCohortComponent" %}
+{% component "unfold/components/chart/cohort.html" with component_class="MyCohortComponent" %}
 {% endcomponent %}
 ```
 
@@ -25,7 +25,7 @@ If you don't want to use `component_class` parameter, you can prepare `data` in 
 ```html
 {% load unfold %}
 
-{% component "unfold/components/cohort.html" with data=my_data_variable data=my_data %}
+{% component "unfold/components/chart/cohort.html" with data=my_data_variable data=my_data %}
 {% endcomponent %}
 ```
 


### PR DESCRIPTION
the path for the `cohort.html` in the documentation was wrong,  I have just fixed it.