### PR TITLE
fix(json): properly display JSON strings

### DIFF
--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -141,6 +141,9 @@ def prettify_json(data: Any) -> Optional[str]:
         )
         return highlight(response, JsonLexer(), formatter)
 
+    if isinstance(data, str):
+        data = json.loads(data)
+    
     response = json.dumps(data, sort_keys=True, indent=4)
 
     return mark_safe(

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -143,7 +143,7 @@ def prettify_json(data: Any) -> Optional[str]:
 
     if isinstance(data, str):
         data = json.loads(data)
-    
+
     response = json.dumps(data, sort_keys=True, indent=4)
 
     return mark_safe(


### PR DESCRIPTION
I had a django model with several JSONFields and noticed that one rather big JSON object/string was displayed with double quotes like this:

![image](https://github.com/user-attachments/assets/374349d1-069e-4dde-a8c5-39fa8ef7d761)

In the database and on non-admin pages where I use a custom template tag, it was displayed properly.

With this little addition, it will be displayed in the admin page properly, too:
![image](https://github.com/user-attachments/assets/f47c2982-d0af-46f2-8f5f-fb5e1675fe37)

Other JSONFields will be displayed as before, so this is not a breaking change.