### PR TITLE
chore: typo

### DIFF
--- a/docs/configuration/modeladmin.md
+++ b/docs/configuration/modeladmin.md
@@ -45,7 +45,7 @@ class CustomAdminClass(ModelAdmin):
     # Position horizontal scrollbar in changelist at the top
     list_horizontal_scrollbar_top = False
 
-    # Dsable select all action in changelist
+    # Disable select all action in changelist
     list_disable_select_all = False
 
 


### PR DESCRIPTION
typo text in docs