### PR TITLE
fix: correct tab links for inlines in non-Latin languages

### DIFF
--- a/src/unfold/templates/admin/edit_inline/stacked.html
+++ b/src/unfold/templates/admin/edit_inline/stacked.html
@@ -1,6 +1,6 @@
 {% load admin_urls i18n unfold %}
 
-<div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-type="stacked" data-inline-formset="{{ inline_admin_formset.inline_formset_data }}" {% if inline_admin_formset.opts.tab %}x-show="activeTab == '{{ inline_admin_formset.opts.verbose_name|slugify }}'"{% else %}x-show="activeTab == 'general'"{% endif %}>
+<div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-type="stacked" data-inline-formset="{{ inline_admin_formset.inline_formset_data }}" {% if inline_admin_formset.opts.tab %}x-show="activeTab == '{{ inline_admin_formset.opts.class_name|slice:':-6'|slugify }}'"{% else %}x-show="activeTab == 'general'"{% endif %}>
     <fieldset class="module relative {{ inline_admin_formset.classes }}" aria-labelledby="{{ inline_admin_formset.formset.prefix }}-heading">
         {% if inline_admin_formset.is_collapsible %}<details><summary>{% endif %}
 

--- a/src/unfold/templates/admin/edit_inline/tabular.html
+++ b/src/unfold/templates/admin/edit_inline/tabular.html
@@ -1,6 +1,6 @@
 {% load admin_modify admin_urls i18n static unfold %}
 
-<div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-type="tabular" data-inline-formset="{{ inline_admin_formset.inline_formset_data }}" {% if inline_admin_formset.opts.tab %}x-show="activeTab == '{{ inline_admin_formset.opts.verbose_name|slugify }}'"{% else %}x-show="activeTab == 'general'"{% endif %}>
+<div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-type="tabular" data-inline-formset="{{ inline_admin_formset.inline_formset_data }}" {% if inline_admin_formset.opts.tab %}x-show="activeTab == '{{ inline_admin_formset.opts.class_name|slice:':-6'|slugify }}'"{% else %}x-show="activeTab == 'general'"{% endif %}>
     <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
         {{ inline_admin_formset.formset.management_form }}
 

--- a/src/unfold/templates/unfold/helpers/tab_list.html
+++ b/src/unfold/templates/unfold/helpers/tab_list.html
@@ -28,9 +28,9 @@
                         {% for inline in inlines_list %}
                             <li class="border-b last:border-b-0 md:border-b-0 md:mr-8 dark:border-base-800">
                                 <a class="block cursor-pointer font-medium px-3 py-2 md:py-4 md:px-0"
-                                   href="#{{ inline.opts.verbose_name|slugify }}"
-                                   x-on:click="activeTab = '{{ inline.opts.verbose_name|slugify }}'"
-                                   x-bind:class="{'border-b border-base-200 dark:border-base-800 md:border-primary-500 dark:md:!border-primary-600 font-semibold -mb-px text-primary-600 dark:text-primary-500': activeTab == '{{ inline.opts.verbose_name|slugify }}', 'hover:text-primary-600 dark:hover:text-primary-500 dark:border-base-800': activeTab != '{{ inline.opts.verbose_name|slugify }}'}">
+                                   href="#{{ inline.opts.class_name|slice:':-6'|slugify }}"
+                                   x-on:click="activeTab = '{{ inline.opts.class_name|slice:':-6'|slugify }}'"
+                                   x-bind:class="{'border-b border-base-200 dark:border-base-800 md:border-primary-500 dark:md:!border-primary-600 font-semibold -mb-px text-primary-600 dark:text-primary-500': activeTab == '{{ inline.opts.class_name|slice:':-6'|slugify }}', 'hover:text-primary-600 dark:hover:text-primary-500 dark:border-base-800': activeTab != '{{ inline.opts.class_name|slice:':-6'|slugify }}'}">
                                     {% if inline.formset.max_num == 1 %}
                                         {{ inline.opts.verbose_name|capfirst }}
                                     {% else %}


### PR DESCRIPTION
Previously, inline tab links were generated using `opts.verbose_name|slugify`, which fails in languages like Persian that slugify doesn't support. This fix ensures that tab links use a reliable model-based identifier which translation doesn't change it(class_name), preventing broken navigation in non-Latin languages.