### PR TITLE
docs: changelist action permission usage in docs

### DIFF
--- a/docs/actions/changelist.md
+++ b/docs/actions/changelist.md
@@ -25,8 +25,8 @@ from unfold.decorators import action
 class UserAdmin(ModelAdmin):
     actions_list = ["changelist_action"]
 
-    @action(description=_("Changelist action"), url_path="changelist-action")
-    def changelist_action(self, request: HttpRequest, permissions=["changelist_action"]):
+    @action(description=_("Changelist action"), url_path="changelist-action", permissions=["changelist_action"])
+    def changelist_action(self, request: HttpRequest):
         return redirect(
           reverse_lazy("admin:users_user_changelist")
         )


### PR DESCRIPTION
Current changelist action example has permissions array set as one of method arguments, instead of being passed to `@action` decorator. 

![image](https://github.com/user-attachments/assets/57b53e55-b789-4f65-827d-9db5e3523568)
