### PR TITLE
feat: Add pagination support for simple_history integration

### DIFF
--- a/src/unfold/contrib/simple_history/templates/simple_history/object_history.html
+++ b/src/unfold/contrib/simple_history/templates/simple_history/object_history.html
@@ -9,8 +9,24 @@
         </p>
     {% endif %}
 
-    {% if historical_records %}
+    {% if page_obj.object_list %}
         {% include object_history_list_template %}
+        <div class="bg-base-50 flex my-4 items-center p-3 rounded dark:bg-base-800">
+            {% if pagination_required %}
+                {% for i in page_range %}
+                    <span class="pr-4">
+                        {% if i == page_obj.paginator.ELLIPSIS %}
+                            {{ page_obj.paginator.ELLIPSIS }}
+                        {% elif i == page_obj.number %}
+                            <span class="font-medium text-primary-600">{{ i }}</span>
+                        {% else %}
+                            <a href="?{{ page_var }}={{ i }}" {% if i == page_obj.paginator.num_pages %} class="end" {% endif %}>{{ i }}</a>
+                        {% endif %}
+                    </span>
+                {% endfor %}
+            {% endif %}
+            {{ page_obj.paginator.count }} {% blocktranslate count counter=page_obj.paginator.count %}entry{% plural %}entries{% endblocktranslate %}
+        </div>
     {% else %}
         <p class="mb-3 px-3 py-3 rounded text-sm last:mb-8 bg-amber-100 text-amber-600 dark:bg-amber-600/20 dark:border-amber-600/10">
             {% trans "This object doesn't have a change history." %}

--- a/src/unfold/contrib/simple_history/templates/simple_history/object_history_list.html
+++ b/src/unfold/contrib/simple_history/templates/simple_history/object_history_list.html
@@ -39,7 +39,7 @@
     </thead>
 
     <tbody>
-        {% for record in historical_records %}
+        {% for record in page_obj %}
             <tr class="block border mb-3 rounded shadow-sm lg:table-row lg:border-none lg:mb-0 lg:shadow-none dark:border-base-800">
                 <td class="align-middle flex border-t border-base-200 font-normal px-3 py-2 text-left before:flex before:capitalize before:content-[attr(data-label)] before:items-center before:mr-auto first:border-t-0 lg:before:hidden lg:first:border-t lg:py-3 lg:table-cell dark:border-base-800" data-label="{% trans 'Object' %}">
                     <a href="{% url opts|admin_urlname:'simple_history' object.pk record.pk %}">


### PR DESCRIPTION
django-simple-history 3.8.0 introduced pagination for the object history listing.

This is a proposed attempt of a fix for #1036.

It should be noted this will only work with django-simple-history >= 3.8.0.

If support for older versions needs to be retained, more thought needs to be put into this.