### PR TITLE
feat: changelist boolean_text option

### DIFF
--- a/docs/configuration/modeladmin.md
+++ b/docs/configuration/modeladmin.md
@@ -45,7 +45,7 @@ class CustomAdminClass(ModelAdmin):
     # Position horizontal scrollbar in changelist at the top
     list_horizontal_scrollbar_top = False
 
-    # Dsable select all action in changelist
+    # Disable select all action in changelist
     list_disable_select_all = False
 
     # Custom actions

--- a/docs/configuration/modeladmin.md
+++ b/docs/configuration/modeladmin.md
@@ -48,6 +48,9 @@ class CustomAdminClass(ModelAdmin):
     # Disable select all action in changelist
     list_disable_select_all = False
 
+    # Set to False to hide text for boolean fields in changelist
+    list_boolean_text = True
+
     # Custom actions
     actions_list = []  # Displayed above the results list
     actions_row = []  # Displayed in a table row in results list

--- a/docs/development/devcontainer.md
+++ b/docs/development/devcontainer.md
@@ -10,7 +10,9 @@ Unfold already contains prepared support for VS Code development. After cloning 
 
 ## Development server
 
-VS Code will build an image and install Python dependencies. After the installation is complete, VS Code will start a container where you can develop directly. Unfold contains an example development application with basic Unfold configuration available in the `tests/server` directory. To start a development Django server, navigate to the `tests/server` folder and run `python manage.py runserver 0.0.0.0:8000`. Make sure to run this command from the VS Code terminal that is connected to the running container.
+VS Code will build an image and install Python dependencies. After the installation is complete, VS Code will start a container where you can develop directly. Unfold contains an example development application with basic Unfold configuration available in the `tests/server` directory.
+
+To start a development Django server, navigate to the `tests/server` folder and create a superuser by running `python tests/server/manage.py createsuperuser`. Then run `python manage.py runserver 0.0.0.0:8000`. Make sure to run this command from the VS Code terminal that is connected to the running container. You can then open your browser to http://localhost:8000/admin/ and log in using the user you just created.
 
 **Note:** This is not a production-ready server. Use it only for running tests or developing features & fixes.
 

--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -40,6 +40,7 @@ class ModelAdmin(BaseModelAdminMixin, ActionModelAdminMixin, BaseModelAdmin):
     action_form = ActionForm
     custom_urls = ()
     add_fieldsets = ()
+    list_boolean_text = True
     list_horizontal_scrollbar_top = False
     list_filter_submit = False
     list_filter_sheet = True

--- a/src/unfold/templates/unfold/helpers/boolean.html
+++ b/src/unfold/templates/unfold/helpers/boolean.html
@@ -1,8 +1,9 @@
 {% load i18n %}
 
 <div class="flex items-center ">
-    <div class="block mr-3 outline rounded-full ml-1 h-1 w-1 {% if value == '' or value == None %}bg-base-500 outline-gray-500/20{% elif value %}bg-green-500 outline-green-200 dark:outline-green-500/20{% else %}bg-red-500 outline-red-200 dark:outline-red-500/20{% endif %}"></div>
+    <div class="block {% if list_boolean_text %}mr-3 {% endif %}outline rounded-full ml-1 h-1 w-1 {% if value == '' or value == None %}bg-base-500 outline-gray-500/20{% elif value %}bg-green-500 outline-green-200 dark:outline-green-500/20{% else %}bg-red-500 outline-red-200 dark:outline-red-500/20{% endif %}"></div>
 
+    {% if list_boolean_text %}
     <span>
         {% if value == '' or value == None %}
             {% trans 'Unknown' %}
@@ -12,4 +13,5 @@
             {% trans 'False' %}
         {% endif %}
     </span>
+    {% endif %}
 </div>

--- a/src/unfold/templates/unfold/helpers/boolean.html
+++ b/src/unfold/templates/unfold/helpers/boolean.html
@@ -4,14 +4,14 @@
     <div class="block {% if list_boolean_text %}mr-3 {% endif %}outline rounded-full ml-1 h-1 w-1 {% if value == '' or value == None %}bg-base-500 outline-gray-500/20{% elif value %}bg-green-500 outline-green-200 dark:outline-green-500/20{% else %}bg-red-500 outline-red-200 dark:outline-red-500/20{% endif %}"></div>
 
     {% if list_boolean_text %}
-    <span>
-        {% if value == '' or value == None %}
-            {% trans 'Unknown' %}
-        {% elif value %}
-            {% trans 'True' %}
-        {% else %}
-            {% trans 'False' %}
-        {% endif %}
-    </span>
+        <span>
+            {% if value == '' or value == None %}
+                {% trans 'Unknown' %}
+            {% elif value %}
+                {% trans 'True' %}
+            {% else %}
+                {% trans 'False' %}
+            {% endif %}
+        </span>
     {% endif %}
 </div>

--- a/src/unfold/templatetags/unfold_list.py
+++ b/src/unfold/templatetags/unfold_list.py
@@ -231,7 +231,12 @@ def items_for_result(cl: ChangeList, result: HttpRequest, form) -> SafeText:
                 elif header:
                     result_repr = display_for_header(value, empty_value_display)
                 else:
-                    result_repr = display_for_value(value, empty_value_display, boolean)
+                    result_repr = display_for_value(
+                        value,
+                        empty_value_display,
+                        boolean,
+                        cl.model_admin.list_boolean_text,
+                    )
 
                 if isinstance(value, (datetime.date, datetime.time)):
                     row_classes.append("nowrap")
@@ -243,7 +248,12 @@ def items_for_result(cl: ChangeList, result: HttpRequest, form) -> SafeText:
                     else:
                         result_repr = field_val
                 else:
-                    result_repr = display_for_field(value, f, empty_value_display)
+                    result_repr = display_for_field(
+                        value,
+                        f,
+                        empty_value_display,
+                        cl.model_admin.list_boolean_text,
+                    )
                 if isinstance(
                     f, (models.DateField, models.TimeField, models.ForeignKey)
                 ):

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -15,8 +15,11 @@ from django.utils.safestring import SafeText, mark_safe
 from .exceptions import UnfoldException
 
 
-def _boolean_icon(field_val: Any) -> str:
-    return render_to_string("unfold/helpers/boolean.html", {"value": field_val})
+def _boolean_icon(field_val: Any, list_boolean_text: bool = True) -> str:
+    return render_to_string(
+        "unfold/helpers/boolean.html",
+        {"value": field_val, "list_boolean_text": list_boolean_text},
+    )
 
 
 def display_for_header(value: Iterable, empty_value_display: str) -> SafeText:
@@ -63,10 +66,13 @@ def display_for_label(value: Any, empty_value_display: str, label: Any) -> SafeT
 
 
 def display_for_value(
-    value: Any, empty_value_display: str, boolean: bool = False
+    value: Any,
+    empty_value_display: str,
+    boolean: bool = False,
+    list_boolean_text: bool = True,
 ) -> str:
     if boolean:
-        return _boolean_icon(value)
+        return _boolean_icon(value, list_boolean_text)
     elif value is None:
         return empty_value_display
     elif isinstance(value, bool):
@@ -83,7 +89,9 @@ def display_for_value(
         return str(value)
 
 
-def display_for_field(value: Any, field: Any, empty_value_display: str) -> str:
+def display_for_field(
+    value: Any, field: Any, empty_value_display: str, list_boolean_text: bool = True
+) -> str:
     if getattr(field, "flatchoices", None):
         try:
             return dict(field.flatchoices).get(value, empty_value_display)
@@ -93,7 +101,7 @@ def display_for_field(value: Any, field: Any, empty_value_display: str) -> str:
             value = make_hashable(value)
             return dict(flatchoices).get(value, empty_value_display)
     elif isinstance(field, models.BooleanField):
-        return _boolean_icon(value)
+        return _boolean_icon(value, list_boolean_text)
     elif value is None or value == "":
         return empty_value_display
     elif isinstance(field, models.DateTimeField):


### PR DESCRIPTION
Adds a ModelAdmin option to show/hide boolean field "True/False/None" text in the changelist. Setting it to `False` allows for narrower boolean field columns like the standard Django admin interface. See "Staff status" and "Active" columns in the examples below:

##### `list_boolean_text = True`
<img width="1136" alt="Screenshot 2025-02-28 at 11 04 27 PM" src="https://github.com/user-attachments/assets/1e471f53-0076-4da4-8ce3-4859cb07f8f8" />

##### `list_boolean_text = False`
<img width="1136" alt="Screenshot 2025-02-28 at 11 04 39 PM" src="https://github.com/user-attachments/assets/ff721806-db7a-49ef-aa7a-94b27c44885b" />

##### Standard Django Admin
<img width="1136" alt="Screenshot 2025-02-28 at 11 05 06 PM" src="https://github.com/user-attachments/assets/1da08c44-811d-4489-ad57-0c8dc2b23505" />

I prefer the standard, more-compact approach of just showing the icon. Happy to provide screenshots of a changelist with more columns to show how it really helps if needed.

Couldn't find many docs on contributing to this project or its principles, so just let me know if my approach is out of line with what you'd like and I can adjust it.