### PR TITLE
feat: add styles for django-parler language tabs

### DIFF
--- a/src/unfold/styles.css
+++ b/src/unfold/styles.css
@@ -662,3 +662,22 @@ trix-toolbar[id^="trix-toolbar-"] {
 .simplebar-horizontal-scrollbar-top .simplebar-track.simplebar-horizontal {
   @apply top-9
 }
+
+/*******************************************************
+ django-parler
+ *******************************************************/
+div.parler-language-tabs {
+    @apply flex gap-2 lg:gap-4 mb-6 px-4 py-3 flex-row lg:-mx-4 m-0 p-1 rounded text-sm bg-base-100 border-0 border-b-0 dark:bg-white/[.04] after:hidden
+}
+
+div.parler-language-tabs span {
+    @apply top-auto;
+}
+
+div.parler-language-tabs span.available {
+    @apply flex flex-row items-center m-0 px-2.5 py-1 rounded text-sm text-base-400 font-medium bg-transparent border-0 border-transparent hover:bg-base-700/[.04] hover:text-base-700 dark:hover:bg-white/[.04] dark:hover:text-white;
+}
+
+div.parler-language-tabs span.current {
+    @apply items-center px-2.5 py-1 rounded text-base-700 font-medium bg-white border-transparent shadow-sm hover:bg-white dark:bg-base-900 dark:text-white dark:hover:bg-base-900;
+}


### PR DESCRIPTION
Follows the styling of django-modeltranslation and collapsible fieldset. Uses tab instead of pills layout because it's implemented outside of content fieldsets.

<img width="1417" alt="django-parler-tabs" src="https://github.com/user-attachments/assets/0798d5f0-6f36-4d39-846e-36072f3a8c08" />

<img width="627" alt="django-parler-tabs-mobile" src="https://github.com/user-attachments/assets/767c43a7-63ca-44fa-ba17-a2506c591b64" />
