### PR TITLE
fix: remove horizontal padding for horizontal filter options

### DIFF
--- a/src/unfold/templates/admin/filter.html
+++ b/src/unfold/templates/admin/filter.html
@@ -15,7 +15,7 @@
         <ul class="dark:bg-base-900 border border-base-200 flex min-w-20 rounded shadow-sm text-font-default-light dark:border-base-700 dark:text-font-default-dark w-full">
             {% for choice in choices %}
                 <li class="basis-1/3 border-r border-base-200 flex-grow truncate last:border-r-0 dark:border-base-700 {% if choice.selected %}font-semibold text-primary-600 dark:text-primary-500 {% else %}hover:text-base-700 dark:hover:text-base-200{% endif %}">
-                    <a href="{{ choice.query_string|iriencode }}" title="{{ choice.display }}" class="block px-3 py-2 text-center hover:text-primary-600 dark:hover:text-primary-500">
+                    <a href="{{ choice.query_string|iriencode }}" title="{{ choice.display }}" class="block py-2 text-center hover:text-primary-600 dark:hover:text-primary-500">
                         {{ choice.display }}
                     </a>
                 </li>


### PR DESCRIPTION
Small styling fix for horizontal choice/boolean filters by removing horizontal padding. 

Example before:
![Screenshot from 2025-03-05 12-36-26](https://github.com/user-attachments/assets/0be94a50-a12e-41eb-b02c-12433bc380f5)

Example after:
![Screenshot from 2025-03-05 12-39-11](https://github.com/user-attachments/assets/1a2d52ae-88d3-4186-b747-923b2b0c7971)
