### PR TITLE
Add support for django-money in display_for_field. Fixes: #942

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ version = "3.8.1"
 description = "ASGI specs, helper code, and adapters"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47"},
     {file = "asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"},
@@ -29,6 +29,21 @@ typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 
 [package.extras]
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
+
+[[package]]
+name = "babel"
+version = "2.17.0"
+description = "Internationalization utilities"
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"},
+    {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
+]
+
+[package.extras]
+dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
 
 [[package]]
 name = "cachetools"
@@ -214,7 +229,7 @@ version = "4.2.19"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "Django-4.2.19-py3-none-any.whl", hash = "sha256:a104e13f219fc55996a4e416ef7d18ab4eeb44e0aa95174c192f16cda9f94e75"},
     {file = "Django-4.2.19.tar.gz", hash = "sha256:6c833be4b0ca614f0a919472a1028a3bbdeb6f056fa04023aeb923346ba2c306"},
@@ -228,6 +243,27 @@ tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
+
+[[package]]
+name = "django-money"
+version = "3.5.3"
+description = "Adds support for using money and currency fields in django models and forms. Uses py-moneyed as the money implementation."
+optional = false
+python-versions = ">=3.7"
+groups = ["test"]
+files = [
+    {file = "django_money-3.5.3-py3-none-any.whl", hash = "sha256:3020c0f6b77eb4c30bdd711c7c660af67ed4b7a4750fdbdf5894788848dc6fc6"},
+    {file = "django_money-3.5.3.tar.gz", hash = "sha256:cb8ef1adea8c682b792cc565ace45ace9525de26e3b116290951cd78c7393eab"},
+]
+
+[package.dependencies]
+Django = ">=2.2"
+py-moneyed = ">=2.0,<3.1"
+setuptools = "*"
+
+[package.extras]
+exchange = ["certifi"]
+test = ["django-stubs", "mixer", "mypy", "pytest (>=8.2,<8.3)", "pytest-cov", "pytest-django"]
 
 [[package]]
 name = "dotty-dict"
@@ -530,6 +566,26 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py-moneyed"
+version = "3.0"
+description = "Provides Currency and Money classes for use in your Python code."
+optional = false
+python-versions = ">=3.7"
+groups = ["test"]
+files = [
+    {file = "py-moneyed-3.0.tar.gz", hash = "sha256:4906f0f02cf2b91edba2e156f2d4e9a78f224059ab8c8fa2ff26230c75d894e8"},
+    {file = "py_moneyed-3.0-py3-none-any.whl", hash = "sha256:9583a14f99c05b46196193d8185206e9b73c8439fc8a5eee9cfc7e733676d9bb"},
+]
+
+[package.dependencies]
+babel = ">=2.8.0"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+tests = ["pytest (>=2.3.0)", "tox (>=1.6.0)"]
+type-tests = ["mypy (>=0.812)", "pytest (>=2.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "pydantic"
@@ -857,7 +913,7 @@ version = "75.8.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["dev", "test"]
 files = [
     {file = "setuptools-75.8.2-py3-none-any.whl", hash = "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"},
     {file = "setuptools-75.8.2.tar.gz", hash = "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2"},
@@ -925,7 +981,7 @@ version = "0.5.3"
 description = "A non-validating SQL parser."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"},
     {file = "sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"},
@@ -1029,7 +1085,7 @@ files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-markers = {main = "python_version < \"3.11\"", test = "python_version < \"3.11\""}
+markers = {main = "python_version < \"3.11\""}
 
 [[package]]
 name = "tzdata"
@@ -1037,7 +1093,7 @@ version = "2025.1"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["main"]
+groups = ["main", "test"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"},
@@ -1107,4 +1163,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "f81dd0615c11c87e2e070ffa114c8f69a8e7583aea44b4bfab3b3910f44c66dc"
+content-hash = "21d0e379d868c1e2e207cd9f9e6acff3bec0168b9f1889764f38965d69e4302a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ django = ">=4.2"
 pytest = "^8.3"
 pytest-django = "^4.9"
 tox = "^4.21"
+django-money = "^3.5.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -14,6 +14,13 @@ from django.utils.safestring import SafeText, mark_safe
 
 from .exceptions import UnfoldException
 
+try:
+    from djmoney.models.fields import MoneyField
+    from djmoney.money import Money
+except ImportError:
+    MoneyField = None
+    Money = None
+
 
 def _boolean_icon(field_val: Any) -> str:
     return render_to_string("unfold/helpers/boolean.html", {"value": field_val})
@@ -75,6 +82,8 @@ def display_for_value(
         return formats.localize(timezone.template_localtime(value))
     elif isinstance(value, (datetime.date, datetime.time)):
         return formats.localize(value)
+    elif Money is not None and isinstance(value, Money):
+        return str(value)
     elif isinstance(value, (int, decimal.Decimal, float)):
         return formats.number_format(value)
     elif isinstance(value, (list, tuple)):
@@ -100,6 +109,8 @@ def display_for_field(value: Any, field: Any, empty_value_display: str) -> str:
         return formats.localize(timezone.template_localtime(value))
     elif isinstance(field, (models.DateField, models.TimeField)):
         return formats.localize(value)
+    elif MoneyField is not None and isinstance(field, MoneyField):
+        return str(value)
     elif isinstance(field, models.DecimalField):
         return formats.number_format(value, field.decimal_places)
     elif isinstance(field, (models.IntegerField, models.FloatField)):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+from django.utils.translation import override
+from djmoney.models.fields import MoneyField
+from djmoney.money import Money
+
+from unfold.utils import display_for_field
+
+
+def test_display_for_field_money():
+    """Test that display_for_field correctly formats MoneyField values."""
+
+    # Test with USD currency
+    money_value = Money(100, "USD")
+    result = display_for_field(money_value, MoneyField(), empty_value_display="-")
+    assert result == "$100.00"
+
+    # Test with EUR currency
+    money_value_eur = Money(50, "EUR")
+    result_eur = display_for_field(
+        money_value_eur, MoneyField(), empty_value_display="-"
+    )
+    assert result_eur == "€50.00"
+
+    # Test with None value
+    result_none = display_for_field(None, MoneyField(), empty_value_display="-")
+    assert result_none == "-"
+
+    with override("de"):
+        # Test with USD currency
+        money_value = Money(100, "USD")
+        result = display_for_field(money_value, MoneyField(), empty_value_display="-")
+        assert result == "100,00\xa0$"
+
+        # Test with EUR currency
+        money_value_eur = Money(50, "EUR")
+        result_eur = display_for_field(
+            money_value_eur, MoneyField(), empty_value_display="-"
+        )
+        assert result_eur == "50,00\xa0€"
+
+        # Test with None value
+        result_none = display_for_field(None, MoneyField(), empty_value_display="-")
+        assert result_none == "-"


### PR DESCRIPTION
This uses `str(value)` to display `django-money` value in `display_for_field` and `display_for_value`. Preview follows

I'm unsure if `display_for_value` is needed.

`en`

![image](https://github.com/user-attachments/assets/8969fa76-39aa-4b13-899b-d50fac1b8760)

`de`

![image](https://github.com/user-attachments/assets/c72709b4-3c40-4966-bb01-3d47492c35b0)


Fixes: #942