### PR TITLE
Add option to have a stripe with ENVIRONMENT name on top of the page. Fixes: #1012

### DIFF
--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -167,10 +167,15 @@ def dashboard_callback(request, context):
 
 def environment_callback(request):
     """
-    Callback has to return a list of two values represeting text value and the color
-    type of the label displayed in top right corner.
+    Callback has to return a list of three values represeting text value and the color
+    type of the label displayed in top right corner. Third value indicates whether the
+    stripe should be displayed on top of the page or not.
     """
-    return ["Production", "danger"] # info, danger, warning, success
+    return [
+        "Production",  # Text value
+        "danger",      # info, danger, warning, success, primary
+        True           # Show stripe
+    ]
 
 
 def badge_callback(request):

--- a/src/unfold/templates/admin/base.html
+++ b/src/unfold/templates/admin/base.html
@@ -11,6 +11,10 @@
         {% endif %}
 
         <div id="main" class="flex-grow min-w-0"  x-resize="mainWidth = $width">
+            {% if environment and environment.2 %}
+                {% include "unfold/helpers/stripe.html" with text=environment.0 type=environment.1 %}
+            {% endif %}
+
             {% include "unfold/helpers/header.html" %}
 
             {% if not is_popup %}

--- a/src/unfold/templates/unfold/helpers/stripe.html
+++ b/src/unfold/templates/unfold/helpers/stripe.html
@@ -1,0 +1,16 @@
+<div class="w-full py-4 text-center font-semibold
+            {% if type == 'info' %}
+                bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-400
+            {% elif type == 'danger' %}
+                bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400
+            {% elif type == 'warning' %}
+                bg-orange-100 text-orange-700 dark:bg-orange-500/20 dark:text-orange-400
+            {% elif type == 'success' %}
+                bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400
+            {% elif type == 'primary' %}
+                bg-primary-100 text-primary-700 dark:bg-primary-500/20 dark:text-primary-400
+            {% else %}
+                bg-base-100 text-base-700 dark:bg-base-500/20 dark:text-base-200
+            {% endif %}">
+    {{ text }}
+</div>

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -7,7 +7,7 @@ from unfold.sites import UnfoldAdminSite
 
 
 def environment_callback(request):
-    return ["Testing Environment", "warning"]
+    return ["Testing Environment", "warning", True]
 
 
 def environment_title_prefix_callback(request):
@@ -58,7 +58,7 @@ def test_environment_correct_environment_callback():
     request.user = AnonymousUser()
     context = admin_site.each_context(request)
     assert "environment" in context
-    assert context["environment"] == ["Testing Environment", "warning"]
+    assert context["environment"] == ["Testing Environment", "warning", True]
 
 
 @override_settings(


### PR DESCRIPTION
This adds an option to have a stripe with env name on top of the page

![image](https://github.com/user-attachments/assets/eb2ea0be-7a90-4b47-9e3b-6f29793ad6b0)

The `environment_callback` should be changed to `["Development", "primary", True]`, last argument indicates "show&nbsp;stripe".

Fixes: #1012
