### PR TITLE
fix: use the same translation for all "By {filter_title}"

### DIFF
--- a/src/unfold/contrib/filters/admin/dropdown_filters.py
+++ b/src/unfold/contrib/filters/admin/dropdown_filters.py
@@ -25,7 +25,7 @@ class DropdownFilter(admin.SimpleListFilter):
         return (
             {
                 "form": self.form_class(
-                    label=_("By %(filter_title)s") % {"filter_title": self.title},
+                    label=_(" By %(filter_title)s ") % {"filter_title": self.title},
                     name=self.parameter_name,
                     choices=[self.all_option, *self.lookup_choices],
                     data={self.parameter_name: self.value()},
@@ -58,7 +58,7 @@ class ChoicesDropdownFilter(ValueMixin, DropdownMixin, admin.ChoicesFieldListFil
 
         yield {
             "form": self.form_class(
-                label=_("By %(filter_title)s") % {"filter_title": self.title},
+                label=_(" By %(filter_title)s ") % {"filter_title": self.title},
                 name=self.lookup_kwarg,
                 choices=choices,
                 data={self.lookup_kwarg: self.value()},
@@ -88,7 +88,7 @@ class RelatedDropdownFilter(ValueMixin, DropdownMixin, admin.RelatedFieldListFil
     def choices(self, changelist: ChangeList) -> Generator[dict[str, Any], None, None]:
         yield {
             "form": self.form_class(
-                label=_("By %(filter_title)s") % {"filter_title": self.title},
+                label=_(" By %(filter_title)s ") % {"filter_title": self.title},
                 name=self.lookup_kwarg,
                 choices=[self.all_option, *self.lookup_choices],
                 data={self.lookup_kwarg: self.value()},

--- a/src/unfold/contrib/filters/admin/mixins.py
+++ b/src/unfold/contrib/filters/admin/mixins.py
@@ -141,7 +141,7 @@ class AutocompleteMixin:
         yield {
             "form": self.form_class(
                 request=self.request,
-                label=_("By %(filter_title)s") % {"filter_title": self.title},
+                label=_(" By %(filter_title)s ") % {"filter_title": self.title},
                 name=self.lookup_kwarg,
                 choices=(),
                 field=self.field,

--- a/src/unfold/contrib/filters/admin/text_filters.py
+++ b/src/unfold/contrib/filters/admin/text_filters.py
@@ -26,7 +26,7 @@ class TextFilter(admin.SimpleListFilter):
             {
                 "form": self.form_class(
                     name=self.parameter_name,
-                    label=_("By %(filter_title)s") % {"filter_title": self.title},
+                    label=_(" By %(filter_title)s ") % {"filter_title": self.title},
                     data={self.parameter_name: self.value()},
                 ),
             },
@@ -57,7 +57,7 @@ class FieldTextFilter(ValueMixin, admin.FieldListFilter):
         return (
             {
                 "form": self.form_class(
-                    label=_("By %(filter_title)s") % {"filter_title": self.title},
+                    label=_(" By %(filter_title)s ") % {"filter_title": self.title},
                     name=self.lookup_kwarg,
                     data={self.lookup_kwarg: self.value()},
                 ),

--- a/src/unfold/contrib/filters/templates/unfold/filters/filters_numeric_slider.html
+++ b/src/unfold/contrib/filters/templates/unfold/filters/filters_numeric_slider.html
@@ -4,7 +4,7 @@
 {% with choices.0 as choice %}
     <div class="admin-numeric-filter-wrapper">
         <h3 class="font-semibold mb-2 text-font-important-light dark:text-font-important-dark">
-            {% blocktrans with filter_title=title %}By {{ filter_title }}{% endblocktrans %}
+            {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
         </h3>
 
         {% if choice.min is not None and choice.max is not None and choice.step %}


### PR DESCRIPTION
Use consistent/same string already translated in Django for filter labels in all places. 

Here it was already ok: https://github.com/unfoldadmin/django-unfold/blob/1494b95756178a02f1f143411515438df3bddfcc/src/unfold/templates/admin/filter.html#L5



Fix: https://github.com/unfoldadmin/django-unfold/issues/1088