### PR TITLE
feat(json): allow rendering of custom JSONFields which uses django form JSONField as form_class

### DIFF
--- a/src/unfold/fields.py
+++ b/src/unfold/fields.py
@@ -9,6 +9,7 @@ from django.db.models import (
     ManyToManyRel,
     OneToOneField,
 )
+from django.forms import fields
 from django.forms.utils import flatatt
 from django.template.defaultfilters import linebreaksbr
 from django.urls import NoReverseMatch, reverse
@@ -139,7 +140,9 @@ class UnfoldAdminReadonlyField(helpers.AdminReadonlyField):
                     and value is not None
                 ):
                     result_repr = self.get_admin_url(f.remote_field, value)
-                elif isinstance(f, models.JSONField):
+                elif isinstance(f, models.JSONField) or isinstance(
+                    f.formfield(), fields.JSONField
+                ):
                     formatted_output = prettify_json(value)
 
                     if formatted_output:

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from django.conf import settings
 from django.db import models
 from django.db.models import Model
+from django.forms import fields
 from django.template.loader import render_to_string
 from django.utils import formats, timezone
 from django.utils.hashable import make_hashable
@@ -129,7 +130,10 @@ def display_for_field(value: Any, field: Any, empty_value_display: str) -> str:
         return formats.number_format(value, field.decimal_places)
     elif isinstance(field, (models.IntegerField, models.FloatField)):
         return formats.number_format(value)
-    elif isinstance(field, models.FileField) and value:
+    elif (
+        isinstance(field, models.FileField)
+        or isinstance(field.formfield(), fields.JSONField)
+    ) and value:
         return format_html('<a href="{}">{}</a>', value.url, value)
     elif isinstance(field, models.JSONField) and value:
         try:

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -130,12 +130,12 @@ def display_for_field(value: Any, field: Any, empty_value_display: str) -> str:
         return formats.number_format(value, field.decimal_places)
     elif isinstance(field, (models.IntegerField, models.FloatField)):
         return formats.number_format(value)
+    elif isinstance(field, models.FileField) and value:
+        return format_html('<a href="{}">{}</a>', value.url, value)
     elif (
-        isinstance(field, models.FileField)
+        isinstance(field, models.JSONField)
         or isinstance(field.formfield(), fields.JSONField)
     ) and value:
-        return format_html('<a href="{}">{}</a>', value.url, value)
-    elif isinstance(field, models.JSONField) and value:
         try:
             return json.dumps(value, ensure_ascii=False, cls=field.encoder)
         except TypeError:


### PR DESCRIPTION
In our case we created a CompressedJSONField which doesn't inherit from models.JSONField but from models.BinaryField. 
In this custom field, we updated the `formfield` method as described here to use `{"form_class": fields.JSONField}`: https://docs.djangoproject.com/en/5.1/howto/custom-model-fields/#specifying-form-field-for-model-field

With this change, it will additionally check for fields.JSONField and it still works with the models.JSONField.
The content will then be rendered as a regular model.JSONField (prettified) instead of just a regular string.