### PR TITLE
fix: typo on user creation popup form

### DIFF
--- a/src/unfold/templates/admin/auth/user/add_form.html
+++ b/src/unfold/templates/admin/auth/user/add_form.html
@@ -6,7 +6,7 @@
         {% if not is_popup %}
             {% translate 'First, enter a username and password. Then, you’ll be able to edit more user options.' %}
         {% else %}
-            {% translate "Enter a username and password." %}x
+            {% translate "Enter a username and password." %}
         {% endif %}
         <p>
 {% endblock %}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a33ce8a4-94ed-4ae3-bf3d-5a0dddd57ec7)
