### PR TITLE
feat: make header sticky

### DIFF
--- a/src/unfold/templates/unfold/helpers/header.html
+++ b/src/unfold/templates/unfold/helpers/header.html
@@ -1,6 +1,6 @@
 {% if not is_popup %}
     {% block header %}
-        <div class="border-b border-base-200 mb-6 px-4 lg:px-8 dark:border-base-800">
+        <div class="md:sticky top-0 z-50 border-b border-base-200 mb-6 px-4 lg:px-8 bg-white dark:bg-base-900 dark:border-base-800">
             <div class="{% if not cl.model_admin.list_fullwidth %}container{% endif %} flex items-center h-16 mx-auto py-4">
                 <div id="header-inner" class="flex items-center w-full">
                     <div class="flex items-center w-full">


### PR DESCRIPTION
This will add a sticky header

![image](https://github.com/user-attachments/assets/37f599a9-6b12-430e-a026-43f547a0c7e2)

Needs to `npm run tailwind:build`, I didn't to avoid conflicts.
Fixes: #1019 
