### PR TITLE
feat: @display decorator upgrade to show value as link

### DIFF
--- a/src/unfold/decorators.py
+++ b/src/unfold/decorators.py
@@ -93,6 +93,7 @@ def display(
     dropdown: Optional[bool] = None,
     label: Optional[Union[bool, str, dict[str, str]]] = None,
     header: Optional[bool] = None,
+    link: Optional[bool] = None,
 ) -> Callable:
     def decorator(func: Callable[[Model], Any]) -> Callable:
         if boolean is not None and empty_value is not None:

--- a/src/unfold/decorators.py
+++ b/src/unfold/decorators.py
@@ -102,6 +102,8 @@ def display(
             )
         if boolean is not None:
             func.boolean = boolean
+        if link is not None:
+            func.link = link
         if image is not None:
             func.image = image
         if ordering is not None:

--- a/src/unfold/templates/unfold/components/link.html
+++ b/src/unfold/templates/unfold/components/link.html
@@ -1,0 +1,5 @@
+{% spaceless %}
+<a href="{{ href }}" class="text-primary-600 underline font-medium"{% if on_new_tab %} target="_blank"{% endif %}>
+    {{ children }}
+</a>
+{% endspaceless %}

--- a/src/unfold/templatetags/unfold_list.py
+++ b/src/unfold/templatetags/unfold_list.py
@@ -223,6 +223,7 @@ def items_for_result(
                 if field_name == "action_checkbox":
                     row_classes = CHECKBOX_CLASSES
                 boolean = getattr(attr, "boolean", False)
+                link = getattr(attr, "link", False)
                 label = getattr(attr, "label", False)
                 header = getattr(attr, "header", False)
                 dropdown = getattr(attr, "dropdown", False)
@@ -236,7 +237,7 @@ def items_for_result(
                 elif header:
                     result_repr = display_for_header(value, empty_value_display)
                 else:
-                    result_repr = display_for_value(value, empty_value_display, boolean)
+                    result_repr = display_for_value(value, empty_value_display, boolean, link)
 
                 if isinstance(value, (datetime.date, datetime.time)):
                     row_classes.append("nowrap")

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -27,6 +27,10 @@ def _boolean_icon(field_val: Any) -> str:
     return render_to_string("unfold/helpers/boolean.html", {"value": field_val})
 
 
+def _link(href: str, name: str, on_new_tab: bool = False) -> str:
+    return render_to_string("unfold/components/link.html", {"href": href, "children": name, "on_new_tab": on_new_tab})
+
+
 def display_for_header(value: Iterable, empty_value_display: str) -> SafeText:
     if not isinstance(value, list) and not isinstance(value, tuple):
         raise UnfoldException("Display header requires list or tuple")


### PR DESCRIPTION
This is how to show a value as a link on the changelist. Yes, I know that button may be used instead, but it is oversized for me.

```python
@admin.register(MyModel)
class TaskAdmin(ModelAdmin):
    list_display = ["link", "new_tab_link"]

    @display(description="Link", link=True)
    def link(self, obj):
        return 'https://example.com', obj.project

    @display(description="New tab link", link=True)
    def new_tab_link(self, obj):
        return 'https://example.com', obj.project, True
```

Sorry, I am not familiar with Python and Django code style is a mystery for me.