### PR TITLE
ui(tabular_heading): change cursor-pointer to cursor-help

### DIFF
--- a/src/unfold/templates/unfold/helpers/edit_inline/tabular_heading.html
+++ b/src/unfold/templates/unfold/helpers/edit_inline/tabular_heading.html
@@ -9,7 +9,7 @@
                         {{ field.label|capfirst }}
 
                         {% if field.help_text %}
-                            <span class="cursor-pointer material-symbols-outlined ml-2 text-base-400 dark:text-base-500" title="{{ field.help_text|striptags }}">help</span>
+                            <span class="cursor-help material-symbols-outlined ml-2 text-base-400 dark:text-base-500" title="{{ field.help_text|striptags }}">help</span>
                         {% endif %}
                     </span>
                 </th>


### PR DESCRIPTION
Since the `help_text` is just showing as `title` when you mouseover, `cursor-help` is more expected. With `cursor-pointer` one would expect that you can click on it.

Reference:
- https://v3.tailwindcss.com/docs/cursor