### PR TITLE
cyrillic support for slugify

### DIFF
--- a/src/unfold/templates/unfold/helpers/tab_items.html
+++ b/src/unfold/templates/unfold/helpers/tab_items.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n unfold %}
 
 {% if inlines_list or tabs_list %}
     <ul class="border rounded flex flex-col max-md:w-full md:flex-row md:border-b-0 md:border-t-0 md:border-l-0 md:border-r-0 dark:border-base-800">

--- a/src/unfold/templates/unfold/helpers/tab_list.html
+++ b/src/unfold/templates/unfold/helpers/tab_list.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n unfold %}
 
 {% if not is_popup %}
     {% if tabs_list or inlines_list or actions_list or actions_detail or actions_items or nav_global %}

--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -12,12 +12,14 @@ from django.forms import BoundField, Field
 from django.http import HttpRequest
 from django.template import Context, Library, Node, RequestContext, TemplateSyntaxError
 from django.template.base import NodeList, Parser, Token, token_kwargs
+from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.utils.safestring import SafeText, mark_safe
 
 from unfold.components import ComponentRegistry
 from unfold.dataclasses import UnfoldAction
 from unfold.enums import ActionVariant
+from unfold.translit import slugify as _slugify
 from unfold.widgets import UnfoldAdminSplitDateTimeWidget
 
 register = Library()
@@ -535,3 +537,9 @@ def changeform_condition(field: BoundField) -> BoundField:
         field.field.field.widget.attrs["x-model.fill"] = field.field.name
 
     return field
+
+
+@register.filter(is_safe=True, name="slugify")
+@stringfilter
+def slugify(value):
+    return _slugify(value)

--- a/src/unfold/translit.py
+++ b/src/unfold/translit.py
@@ -1,0 +1,160 @@
+"""
+Simple transliteration
+"""
+
+import re
+
+TRANSTABLE = (
+        ("'", "'"),
+        ('"', '"'),
+        ("‘", "'"),
+        ("’", "'"),
+        ("«", '"'),
+        ("»", '"'),
+        ("“", '"'),
+        ("”", '"'),
+        ("–", "-"),  # en dash
+        ("—", "-"),  # em dash
+        ("‒", "-"),  # figure dash
+        ("−", "-"),  # minus
+        ("…", "..."),
+        ("№", "#"),
+        ## upper
+        # three-symbols replacements
+        ("Щ", "Sch"),
+        # on russian->english translation only first replacement will be done
+        # i.e. Sch
+        # but on english->russian translation both variants (Sch and SCH) will play
+        ("Щ", "SCH"),
+        # two-symbol replacements
+        ("Ё", "Yo"),
+        ("Ё", "YO"),
+        ("Ж", "Zh"),
+        ("Ж", "ZH"),
+        ("Ц", "Ts"),
+        ("Ц", "TS"),
+        ("Ч", "Ch"),
+        ("Ч", "CH"),
+        ("Ш", "Sh"),
+        ("Ш", "SH"),
+        ("Ы", "Yi"),
+        ("Ы", "YI"),
+        ("Ю", "YU"),
+        ("Ю", "Yu"),
+        ("Я", "Ya"),
+        ("Я", "YA"),
+        # one-symbol replacements
+        ("А", "A"),
+        ("Б", "B"),
+        ("В", "V"),
+        ("Г", "G"),
+        ("Д", "D"),
+        ("Е", "E"),
+        ("З", "Z"),
+        ("И", "I"),
+        ("Й", "J"),
+        ("К", "K"),
+        ("Л", "L"),
+        ("М", "M"),
+        ("Н", "N"),
+        ("О", "O"),
+        ("П", "P"),
+        ("Р", "R"),
+        ("С", "S"),
+        ("Т", "T"),
+        ("У", "U"),
+        ("Ф", "F"),
+        ("Х", "H"),
+        ("Э", "E"),
+        ("Ъ", "`"),
+        ("Ь", "'"),
+        ## lower
+        # three-symbols replacements
+        ("щ", "sch"),
+        # two-symbols replacements
+        ("ё", "yo"),
+        ("ж", "zh"),
+        ("ц", "ts"),
+        ("ч", "ch"),
+        ("ш", "sh"),
+        ("ы", "yi"),
+        ("ю", "yu"),
+        ("я", "ya"),
+        # one-symbol replacements
+        ("а", "a"),
+        ("б", "b"),
+        ("в", "v"),
+        ("г", "g"),
+        ("д", "d"),
+        ("е", "e"),
+        ("з", "z"),
+        ("и", "i"),
+        ("й", "j"),
+        ("к", "k"),
+        ("л", "l"),
+        ("м", "m"),
+        ("н", "n"),
+        ("о", "o"),
+        ("п", "p"),
+        ("р", "r"),
+        ("с", "s"),
+        ("т", "t"),
+        ("у", "u"),
+        ("ф", "f"),
+        ("х", "h"),
+        ("э", "e"),
+        ("ъ", "`"),
+        ("ь", "'"),
+        # Make english alphabet full: append english-english pairs
+        # for symbols which is not used in russian-english
+        # translations. Used in slugify.
+        ("c", "c"),
+        ("q", "q"),
+        ("y", "y"),
+        ("x", "x"),
+        ("w", "w"),
+        ("1", "1"),
+        ("2", "2"),
+        ("3", "3"),
+        ("4", "4"),
+        ("5", "5"),
+        ("6", "6"),
+        ("7", "7"),
+        ("8", "8"),
+        ("9", "9"),
+        ("0", "0"),
+        )  #: Translation table
+
+RU_ALPHABET = [x[0] for x in TRANSTABLE] #: Russian alphabet that we can translate
+EN_ALPHABET = [x[1] for x in TRANSTABLE] #: English alphabet that we can detransliterate
+ALPHABET = RU_ALPHABET + EN_ALPHABET #: Alphabet that we can (de)transliterate
+
+
+def slugify(in_string):
+    """
+    Prepare string for slug (i.e. URL or file/dir name)
+
+    @param in_string: input string
+    @type in_string: C{basestring}
+
+    @return: slug-string
+    @rtype: C{str}
+
+    @raise ValueError: if in_string is C{str}, but it isn't ascii
+    """
+    try:
+        u_in_string = str(in_string).lower()
+    except UnicodeDecodeError:
+        raise ValueError("We expects when in_string is str type," + \
+                         "it is an ascii, but now it isn't. Use unicode " + \
+                         "in this case.")
+    # convert & to "and"
+    u_in_string = re.sub(r'\&amp\;|\&', ' and ', u_in_string)
+    # replace spaces by hyphen
+    u_in_string = re.sub(r'[-\s]+', '-', u_in_string)
+    # remove symbols that not in alphabet
+    u_in_string = ''.join([symb for symb in u_in_string if symb in ALPHABET])
+    # translify it
+    out_string = translify(u_in_string)
+    # remove non-alpha
+    return re.sub(r'[^\w\s-]', '', out_string).strip().lower()

--- a/src/unfold/translit.py
+++ b/src/unfold/translit.py
@@ -5,129 +5,160 @@ Simple transliteration
 import re
 
 TRANSTABLE = (
-        ("'", "'"),
-        ('"', '"'),
-        ("‘", "'"),
-        ("’", "'"),
-        ("«", '"'),
-        ("»", '"'),
-        ("“", '"'),
-        ("”", '"'),
-        ("–", "-"),  # en dash
-        ("—", "-"),  # em dash
-        ("‒", "-"),  # figure dash
-        ("−", "-"),  # minus
-        ("…", "..."),
-        ("№", "#"),
-        ## upper
-        # three-symbols replacements
-        ("Щ", "Sch"),
-        # on russian->english translation only first replacement will be done
-        # i.e. Sch
-        # but on english->russian translation both variants (Sch and SCH) will play
-        ("Щ", "SCH"),
-        # two-symbol replacements
-        ("Ё", "Yo"),
-        ("Ё", "YO"),
-        ("Ж", "Zh"),
-        ("Ж", "ZH"),
-        ("Ц", "Ts"),
-        ("Ц", "TS"),
-        ("Ч", "Ch"),
-        ("Ч", "CH"),
-        ("Ш", "Sh"),
-        ("Ш", "SH"),
-        ("Ы", "Yi"),
-        ("Ы", "YI"),
-        ("Ю", "YU"),
-        ("Ю", "Yu"),
-        ("Я", "Ya"),
-        ("Я", "YA"),
-        # one-symbol replacements
-        ("А", "A"),
-        ("Б", "B"),
-        ("В", "V"),
-        ("Г", "G"),
-        ("Д", "D"),
-        ("Е", "E"),
-        ("З", "Z"),
-        ("И", "I"),
-        ("Й", "J"),
-        ("К", "K"),
-        ("Л", "L"),
-        ("М", "M"),
-        ("Н", "N"),
-        ("О", "O"),
-        ("П", "P"),
-        ("Р", "R"),
-        ("С", "S"),
-        ("Т", "T"),
-        ("У", "U"),
-        ("Ф", "F"),
-        ("Х", "H"),
-        ("Э", "E"),
-        ("Ъ", "`"),
-        ("Ь", "'"),
-        ## lower
-        # three-symbols replacements
-        ("щ", "sch"),
-        # two-symbols replacements
-        ("ё", "yo"),
-        ("ж", "zh"),
-        ("ц", "ts"),
-        ("ч", "ch"),
-        ("ш", "sh"),
-        ("ы", "yi"),
-        ("ю", "yu"),
-        ("я", "ya"),
-        # one-symbol replacements
-        ("а", "a"),
-        ("б", "b"),
-        ("в", "v"),
-        ("г", "g"),
-        ("д", "d"),
-        ("е", "e"),
-        ("з", "z"),
-        ("и", "i"),
-        ("й", "j"),
-        ("к", "k"),
-        ("л", "l"),
-        ("м", "m"),
-        ("н", "n"),
-        ("о", "o"),
-        ("п", "p"),
-        ("р", "r"),
-        ("с", "s"),
-        ("т", "t"),
-        ("у", "u"),
-        ("ф", "f"),
-        ("х", "h"),
-        ("э", "e"),
-        ("ъ", "`"),
-        ("ь", "'"),
-        # Make english alphabet full: append english-english pairs
-        # for symbols which is not used in russian-english
-        # translations. Used in slugify.
-        ("c", "c"),
-        ("q", "q"),
-        ("y", "y"),
-        ("x", "x"),
-        ("w", "w"),
-        ("1", "1"),
-        ("2", "2"),
-        ("3", "3"),
-        ("4", "4"),
-        ("5", "5"),
-        ("6", "6"),
-        ("7", "7"),
-        ("8", "8"),
-        ("9", "9"),
-        ("0", "0"),
-        )  #: Translation table
+    ("'", "'"),
+    ('"', '"'),
+    ("‘", "'"),
+    ("’", "'"),
+    ("«", '"'),
+    ("»", '"'),
+    ("“", '"'),
+    ("”", '"'),
+    ("–", "-"),  # en dash
+    ("—", "-"),  # em dash
+    ("‒", "-"),  # figure dash
+    ("−", "-"),  # minus
+    ("…", "..."),
+    ("№", "#"),
+    ## upper
+    # three-symbols replacements
+    ("Щ", "Sch"),
+    # on russian->english translation only first replacement will be done
+    # i.e. Sch
+    # but on english->russian translation both variants (Sch and SCH) will play
+    ("Щ", "SCH"),
+    # two-symbol replacements
+    ("Ё", "Yo"),
+    ("Ё", "YO"),
+    ("Ж", "Zh"),
+    ("Ж", "ZH"),
+    ("Ц", "Ts"),
+    ("Ц", "TS"),
+    ("Ч", "Ch"),
+    ("Ч", "CH"),
+    ("Ш", "Sh"),
+    ("Ш", "SH"),
+    ("Ы", "Yi"),
+    ("Ы", "YI"),
+    ("Ю", "YU"),
+    ("Ю", "Yu"),
+    ("Я", "Ya"),
+    ("Я", "YA"),
+    # one-symbol replacements
+    ("А", "A"),
+    ("Б", "B"),
+    ("В", "V"),
+    ("Г", "G"),
+    ("Д", "D"),
+    ("Е", "E"),
+    ("З", "Z"),
+    ("И", "I"),
+    ("Й", "J"),
+    ("К", "K"),
+    ("Л", "L"),
+    ("М", "M"),
+    ("Н", "N"),
+    ("О", "O"),
+    ("П", "P"),
+    ("Р", "R"),
+    ("С", "S"),
+    ("Т", "T"),
+    ("У", "U"),
+    ("Ф", "F"),
+    ("Х", "H"),
+    ("Э", "E"),
+    ("Ъ", "`"),
+    ("Ь", "'"),
+    ## lower
+    # three-symbols replacements
+    ("щ", "sch"),
+    # two-symbols replacements
+    ("ё", "yo"),
+    ("ж", "zh"),
+    ("ц", "ts"),
+    ("ч", "ch"),
+    ("ш", "sh"),
+    ("ы", "yi"),
+    ("ю", "yu"),
+    ("я", "ya"),
+    # one-symbol replacements
+    ("а", "a"),
+    ("б", "b"),
+    ("в", "v"),
+    ("г", "g"),
+    ("д", "d"),
+    ("е", "e"),
+    ("з", "z"),
+    ("и", "i"),
+    ("й", "j"),
+    ("к", "k"),
+    ("л", "l"),
+    ("м", "m"),
+    ("н", "n"),
+    ("о", "o"),
+    ("п", "p"),
+    ("р", "r"),
+    ("с", "s"),
+    ("т", "t"),
+    ("у", "u"),
+    ("ф", "f"),
+    ("х", "h"),
+    ("э", "e"),
+    ("ъ", "`"),
+    ("ь", "'"),
+    # Make english alphabet full: append english-english pairs
+    # for symbols which is not used in russian-english
+    # translations. Used in slugify.
+    ("c", "c"),
+    ("q", "q"),
+    ("y", "y"),
+    ("x", "x"),
+    ("w", "w"),
+    ("1", "1"),
+    ("2", "2"),
+    ("3", "3"),
+    ("4", "4"),
+    ("5", "5"),
+    ("6", "6"),
+    ("7", "7"),
+    ("8", "8"),
+    ("9", "9"),
+    ("0", "0"),
+)  #: Translation table
 
-RU_ALPHABET = [x[0] for x in TRANSTABLE] #: Russian alphabet that we can translate
-EN_ALPHABET = [x[1] for x in TRANSTABLE] #: English alphabet that we can detransliterate
-ALPHABET = RU_ALPHABET + EN_ALPHABET #: Alphabet that we can (de)transliterate
+RU_ALPHABET = [x[0] for x in TRANSTABLE]  #: Russian alphabet that we can translate
+EN_ALPHABET = [
+    x[1] for x in TRANSTABLE
+]  #: English alphabet that we can detransliterate
+ALPHABET = RU_ALPHABET + EN_ALPHABET  #: Alphabet that we can (de)transliterate
+
+
+def translify(in_string, strict=True):
+    """
+    Translify russian text
+
+    @param in_string: input string
+    @type in_string: C{str}
+
+    @param strict: raise error if transliteration is incomplete.
+        (True by default)
+    @type strict: C{bool}
+
+    @return: transliterated string
+    @rtype: C{str}
+
+    @raise ValueError: when string doesn't transliterate completely.
+        Raised only if strict=True
+    """
+    translit = in_string
+    for symb_in, symb_out in TRANSTABLE:
+        translit = translit.replace(symb_in, symb_out)
+
+    if strict and any(ord(symb) > 128 for symb in translit):
+        raise ValueError(
+            "Unicode string doesn't transliterate completely, " + "is it russian?"
+        )
+
+    return translit
 
 
 def slugify(in_string):
@@ -144,17 +175,19 @@ def slugify(in_string):
     """
     try:
         u_in_string = str(in_string).lower()
-    except UnicodeDecodeError:
-        raise ValueError("We expects when in_string is str type," + \
-                         "it is an ascii, but now it isn't. Use unicode " + \
-                         "in this case.")
+    except UnicodeDecodeError as err:
+        raise ValueError(
+            "We expects when in_string is str type,"
+            + "it is an ascii, but now it isn't. Use unicode "
+            + "in this case."
+        ) from err
     # convert & to "and"
-    u_in_string = re.sub(r'\&amp\;|\&', ' and ', u_in_string)
+    u_in_string = re.sub(r"\&amp\;|\&", " and ", u_in_string)
     # replace spaces by hyphen
-    u_in_string = re.sub(r'[-\s]+', '-', u_in_string)
+    u_in_string = re.sub(r"[-\s]+", "-", u_in_string)
     # remove symbols that not in alphabet
-    u_in_string = ''.join([symb for symb in u_in_string if symb in ALPHABET])
+    u_in_string = "".join([symb for symb in u_in_string if symb in ALPHABET])
     # translify it
     out_string = translify(u_in_string)
     # remove non-alpha
-    return re.sub(r'[^\w\s-]', '', out_string).strip().lower()
+    return re.sub(r"[^\w\s-]", "", out_string).strip().lower()


### PR DESCRIPTION
Django default slugify does not support cyrillic symbols. Added minimal translit for support tabs with cyrillic.