### PR TITLE
Feat/sticky header

### DIFF
--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -50,6 +50,7 @@ UNFOLD = {
     "SHOW_HISTORY": True, # show/hide "History" button, default: True
     "SHOW_VIEW_ON_SITE": True, # show/hide "View on site" button, default: True
     "SHOW_BACK_BUTTON": False, # show/hide "Back" button on changeform in header, default: False
+    "STICKY_HEADER": False, # show sticky/static header, default: False
     "ENVIRONMENT": "sample_app.environment_callback", # environment name in header
     "ENVIRONMENT_TITLE_PREFIX": "sample_app.environment_title_prefix_callback", # environment name prefix in title tag
     "DASHBOARD_CALLBACK": "sample_app.dashboard_callback",

--- a/src/unfold/settings.py
+++ b/src/unfold/settings.py
@@ -62,6 +62,7 @@ CONFIG_DEFAULTS = {
         "show_all_applications": False,
         "navigation": {},
     },
+    "STICKY_HEADER": False,
     "TABS": [],
     "LOGIN": {
         "image": None,

--- a/src/unfold/sites.py
+++ b/src/unfold/sites.py
@@ -95,6 +95,7 @@ class UnfoldAdminSite(AdminSite):
             "show_view_on_site": self._get_config("SHOW_VIEW_ON_SITE", request),
             "show_languages": self._get_config("SHOW_LANGUAGES", request),
             "show_back_button": self._get_config("SHOW_BACK_BUTTON", request),
+            "sticky_header": self._get_config("STICKY_HEADER", request),
             "theme": self._get_config("THEME", request),
             "border_radius": self._get_config("BORDER_RADIUS", request),
             "colors": self._get_colors("COLORS", request),

--- a/src/unfold/templates/unfold/helpers/header.html
+++ b/src/unfold/templates/unfold/helpers/header.html
@@ -1,6 +1,6 @@
 {% if not is_popup %}
     {% block header %}
-        <div class="md:sticky top-0 z-50 border-b border-base-200 mb-6 px-4 lg:px-8 bg-white dark:bg-base-900 dark:border-base-800">
+        <div class="{% if sticky_header %}md:sticky top-0 z-50 {% endif %}border-b border-base-200 mb-6 px-4 lg:px-8 bg-white dark:bg-base-900 dark:border-base-800">
             <div class="{% if not cl.model_admin.list_fullwidth %}container{% endif %} flex items-center h-16 mx-auto py-4">
                 <div id="header-inner" class="flex items-center w-full">
                     <div class="flex items-center w-full">

--- a/src/unfold/templates/unfold/helpers/header.html
+++ b/src/unfold/templates/unfold/helpers/header.html
@@ -1,6 +1,6 @@
 {% if not is_popup %}
     {% block header %}
-        <div class="border-b border-base-200 mb-6 px-4 lg:px-8 dark:border-base-800">
+        <div class="md:sticky top-0 z-50 border-b border-base-200 mb-6 px-4 lg:px-8 bg-white dark:bg-base-900 dark:border-base-800">
             <div class="{% if not cl.model_admin.list_fullwidth %}container{% endif %} flex items-center h-16 mx-auto py-4">
                 <div id="header-inner" class="flex items-center w-full">
                     <div class="flex items-center w-full">


### PR DESCRIPTION
Follow up of closed #1168

I've added option to opt-in for sticky header with settings `STICKY_HEADER`

> we need more complex solution which will make the header sticky together with the sidebar header as well.

I don't understand this part of the comment. The header of sidebar already is sticky (always on top when I scroll threw the sidebar content). Could you elaborate please?
![image](https://github.com/user-attachments/assets/6d785401-9571-432d-8e94-e0cb2a79bfe3)

Needs to `npm run tailwind:build`, I didn't to avoid conflicts.
Fixes: https://github.com/unfoldadmin/django-unfold/issues/1019
