### PR TITLE
Fix missing pluralization in form error message translation

### DIFF
--- a/src/unfold/templates/unfold/helpers/messages/errornote.html
+++ b/src/unfold/templates/unfold/helpers/messages/errornote.html
@@ -5,4 +5,3 @@
         {% blocktranslate count counter=errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
     </p>
 {% endif %}
-

--- a/src/unfold/templates/unfold/helpers/messages/errornote.html
+++ b/src/unfold/templates/unfold/helpers/messages/errornote.html
@@ -2,10 +2,7 @@
 
 {% if errors %}
     <p class="errornote bg-red-100 mb-8 text-red-700 px-3 py-3 rounded-default dark:bg-red-500/20 dark:border-red-500/20 dark:text-red-400">
-        {% if errors.items|length == 1 %}
-            {% translate "Please correct the error below." %}
-        {% else %}
-            {% translate "Please correct the errors below." %}
-        {% endif %}
+        {% blocktranslate count counter=errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
     </p>
 {% endif %}
+


### PR DESCRIPTION
Fix missing pluralization in form error message translation

### Issue Description:
When displaying form errors, Unfold's error message ("Please correct the error below.") is not translated correctly, while Django’s built-in admin properly handles localization via pluralization.

This happens because Django admin uses `{% blocktranslate %}` (pluralization), but Unfold uses separate `{% translate %}` calls for singular and plural, causing mismatches with Django's official translation entries.

### Proposed Solution:
Replace separate `{% translate %}` calls with Django’s `{% blocktranslate %}` syntax, matching Django's official admin template.

### Fixes:
- Resolves translation mismatch
- Enables pluralization support consistent with Django’s official translations

