### PR TITLE
feat: Honor field.encoder in prettify_json

### DIFF
--- a/src/unfold/fields.py
+++ b/src/unfold/fields.py
@@ -140,7 +140,7 @@ class UnfoldAdminReadonlyField(helpers.AdminReadonlyField):
                 ):
                     result_repr = self.get_admin_url(f.remote_field, value)
                 elif isinstance(f, models.JSONField):
-                    formatted_output = prettify_json(value)
+                    formatted_output = prettify_json(value, f.encoder)
 
                     if formatted_output:
                         return formatted_output

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -150,7 +150,7 @@ def hex_to_rgb(hex_color: str) -> list[int]:
     return (r, g, b)
 
 
-def prettify_json(data: Any) -> Optional[str]:
+def prettify_json(data: Any, encoder: Any) -> Optional[str]:
     try:
         from pygments import highlight
         from pygments.formatters import HtmlFormatter
@@ -167,7 +167,7 @@ def prettify_json(data: Any) -> Optional[str]:
         )
         return highlight(response, JsonLexer(), formatter)
 
-    response = json.dumps(data, sort_keys=True, indent=4)
+    response = json.dumps(data, sort_keys=True, indent=4, cls=encoder)
 
     return mark_safe(
         f'<div class="block dark:hidden">{format_response(response, "colorful")}</div>'


### PR DESCRIPTION
When users provide a custom json encoder in their field configuration, this configuration should also be honoured while pretty printing the field values.