### PR TITLE
Do not escape HTML in help_text. Fixes: #1263

### DIFF
--- a/src/unfold/templates/unfold/helpers/help_text.html
+++ b/src/unfold/templates/unfold/helpers/help_text.html
@@ -1,5 +1,5 @@
 {% if help_text %}
     <div class="leading-relaxed mt-2 text-xs">
-        {{ help_text }}
+        {{ help_text|safe }}
     </div>
 {% endif %}


### PR DESCRIPTION
To align behavior with Django, the `help_text` should not be HTML escaped ([docs](https://docs.djangoproject.com/en/5.2/ref/models/fields/#django.db.models.Field.help_text)).

Fixes: #1263