### PR TITLE
feat: move form error message above inline tabs

### DIFF
--- a/src/unfold/templates/admin/base.html
+++ b/src/unfold/templates/admin/base.html
@@ -40,6 +40,10 @@
 
             <div class="px-4 pb-4 grow">
                 <div id="content" class="{% if not cl.model_admin.list_fullwidth %}container{% endif %} mx-auto {% block coltype %}colM{% endblock %}">
+
+                    {% include "unfold/helpers/messages/errornote.html" with errors=errors %}
+                    {% include "unfold/helpers/messages/error.html" with errors=adminform.form.non_field_errors %}
+
                     {% if cl %}
                         {% tab_list "changelist" cl.opts %}
                     {% elif opts %}

--- a/src/unfold/templates/admin/change_form.html
+++ b/src/unfold/templates/admin/change_form.html
@@ -85,9 +85,6 @@
                     <input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">
                 {% endif %}
 
-                {% include "unfold/helpers/messages/errornote.html" with errors=errors %}
-                {% include "unfold/helpers/messages/error.html" with errors=adminform.form.non_field_errors %}
-
                 {% block field_sets %}
                     {% with has_conditional_display=adminform.model_admin.conditional_fields %}
                         {% for fieldset in adminform %}


### PR DESCRIPTION
This change just moves the error message banner above the inline tabs, to stay consistent with the placement of other messages in the system. For example, success messages already appear above the inline tabs.

I think it looks much better above the tabs, but this is just a suggestion really!

Before:
![image](https://github.com/user-attachments/assets/c835c815-e4cc-430a-8cca-d4fd61df9672)


After:
![image](https://github.com/user-attachments/assets/97e3926a-4faf-442a-a4df-7be7c5ebea24)