### PR TITLE
fix: @action decorator removes original function metadata

### DIFF
--- a/src/unfold/decorators.py
+++ b/src/unfold/decorators.py
@@ -1,3 +1,4 @@
+import functools
 from collections.abc import Iterable
 from typing import Any, Callable, Optional, Union
 
@@ -22,6 +23,7 @@ def action(
     variant: Optional[ActionVariant] = ActionVariant.DEFAULT,
 ) -> ActionFunction:
     def decorator(func: Callable) -> ActionFunction:
+        @functools.wraps(func)
         def inner(
             model_admin: BaseModelAdmin,
             request: HttpRequest,


### PR DESCRIPTION
Add @functools.wraps(func) to inner function in action decorator

#1411 