### PR TITLE
fix: return response from action method in action_model_admin 

### DIFF
--- a/src/unfold/mixins/action_model_admin.py
+++ b/src/unfold/mixins/action_model_admin.py
@@ -105,7 +105,7 @@ class ActionModelAdminMixin:
             if action.action_name not in request.POST:
                 continue
 
-            action.method(request, obj)
+            return action.method(request, obj)
 
     def get_unfold_action(self, action: str) -> UnfoldAction:
         """


### PR DESCRIPTION
Redirects are not working as described in docs; likely due to not returning the response.
