### PR TITLE
don't show link if readonly URLField is None

### DIFF
--- a/src/unfold/fields.py
+++ b/src/unfold/fields.py
@@ -139,7 +139,7 @@ class UnfoldAdminReadonlyField(helpers.AdminReadonlyField):
                     result_repr = display_for_field(value, f, self.empty_value_display)
                     return conditional_escape(result_repr)
                 elif isinstance(f, models.URLField):
-                    return format_html(
+                    return value and format_html(
                         '<a href="{}" class="text-primary-600 dark:text-primary-500">{}</a>',
                         value,
                         value,


### PR DESCRIPTION
Currently shows a link w/ title and href set to 'None'