### PR TITLE
fix: removed the redundant "All" option from MultipleDropdownFilter

### DIFF
--- a/src/unfold/contrib/filters/admin/dropdown_filters.py
+++ b/src/unfold/contrib/filters/admin/dropdown_filters.py
@@ -22,12 +22,19 @@ class DropdownFilter(admin.SimpleListFilter):
     all_option = ["", _("All")]
 
     def choices(self, changelist: ChangeList) -> tuple[dict[str, Any], ...]:
+        choices = []
+
+        if self.all_option:
+            choices = [self.all_option]
+
+        choices.extend(self.lookup_choices)
+
         return (
             {
                 "form": self.form_class(
                     label=_(" By %(filter_title)s ") % {"filter_title": self.title},
                     name=self.parameter_name,
-                    choices=[self.all_option, *self.lookup_choices],
+                    choices=choices,
                     data={self.parameter_name: self.value()},
                     multiple=self.multiple if hasattr(self, "multiple") else False,
                 ),
@@ -37,6 +44,7 @@ class DropdownFilter(admin.SimpleListFilter):
 
 class MultipleDropdownFilter(DropdownFilter):
     multiple = True
+    all_option = None
 
     def __init__(
         self,


### PR DESCRIPTION
This fixes an issue where multi-value dropdown has an "all" option, which does not do anything and is redundant:
<img width="283" height="128" alt="SCR-20250731-snqf" src="https://github.com/user-attachments/assets/02fe87f9-58a9-4f42-9c72-160f8573c3e1" />
<img width="196" height="230" alt="SCR-20250731-snnd" src="https://github.com/user-attachments/assets/247e4b5d-c6fb-423e-9e58-dedc71145fbd" />

This was solved for checkboxes, so I am just following the pattern in checkboxes:
https://github.com/unfoldadmin/django-unfold/blob/bbc6da46fd36504e233d4d835908632785081f30/src/unfold/contrib/filters/admin/choice_filters.py#L27-L31