### PR TITLE
fix: disable sort functionality on non-sortable changelist

### DIFF
--- a/src/unfold/templates/admin/change_list_results.html
+++ b/src/unfold/templates/admin/change_list_results.html
@@ -8,7 +8,7 @@
 
 {% if results %}
     <div class="{% if cl.search_fields or cl.has_filters %}lg:rounded-b-default{% else %}lg:rounded-default{% endif %} -mx-1 px-1 overflow-x-auto lg:border lg:border-base-200 lg:mx-0 lg:px-0 lg:shadow-xs lg:dark:border-base-800 lg:bg-white lg:dark:bg-base-900 {% if cl.model_admin.list_horizontal_scrollbar_top %}simplebar-horizontal-scrollbar-top{% endif %}" data-simplebar data-simplebar-auto-hide="false">
-        <table id="result_list" class="block border-base-200 border-spacing-none border-separate w-full lg:table" x-sort.ghost x-on:end="sortRecords" data-ordering-field="{{ cl.model_admin.ordering_field }}">
+        <table id="result_list" class="block border-base-200 border-spacing-none border-separate w-full lg:table" {% if cl.model_admin.ordering_field %}x-sort.ghost{% endif %} x-on:end="sortRecords" data-ordering-field="{{ cl.model_admin.ordering_field }}">
             {% include 'unfold/helpers/change_list_headers.html' %}
 
             {% for result in results %}


### PR DESCRIPTION
Hi Lukas!

I've tried sortable changelist feature and works quite well.
But I've seen a bug for non-sortable changelists. They are draggable even though they shouldn't be.

![prev_sortable_changelist](https://github.com/user-attachments/assets/68b6b5c7-8dec-47f5-af64-d0af895ef593)

I tried to fix this issue in this PR.
I hope this feature can be officially released soon. Thank you