### PR TITLE
fix: type hint on model in BaseModelAdminMixin.__init__

### DIFF
--- a/src/unfold/mixins/base_model_admin.py
+++ b/src/unfold/mixins/base_model_admin.py
@@ -18,7 +18,7 @@ from unfold.overrides import FORMFIELD_OVERRIDES
 
 
 class BaseModelAdminMixin:
-    def __init__(self, model: models.Model, admin_site: AdminSite) -> None:
+    def __init__(self, model: type[models.Model], admin_site: AdminSite) -> None:
         overrides = copy.deepcopy(FORMFIELD_OVERRIDES)
 
         for k, v in self.formfield_overrides.items():


### PR DESCRIPTION
See #1483.

The model arg is the class, not an instance of it. 

#### Example

I can see this removes the type checking error from the [`user_model_admin` fixture](https://github.com/unfoldadmin/django-unfold/blob/main/tests/fixtures.py#L54).

where e.g. with pyright I was previously seeing:

```
Argument of type "type[AbstractUser]" cannot be assigned to parameter "model" of type "Model" in function "__init__"
Type "type[AbstractUser]" is not assignable to type 
```