### PR TITLE
Fixes unfoldadmin/django-unfold#1503

### DIFF
--- a/src/unfold/templates/unfold/helpers/command.html
+++ b/src/unfold/templates/unfold/helpers/command.html
@@ -50,4 +50,5 @@
                 <div id="command-results-note"></div>
             </div>
         </div>
+    </div>
 {% endif %}


### PR DESCRIPTION
Closes the outer `div` tag in src/unfold/templates/unfold/helpers/command.html.