### PR TITLE
fix: template layout without constance config

### DIFF
--- a/src/unfold/contrib/constance/templates/admin/constance/change_list.html
+++ b/src/unfold/contrib/constance/templates/admin/constance/change_list.html
@@ -22,30 +22,30 @@
                     {{ field }}
                 {% endfor %}
 
-                {% if fieldsets %}
-                    <div class="border border-base-200 rounded-default overflow-x-auto simplebar-horizontal-scrollbar-top dark:border-base-800" data-simplebar data-simplebar-auto-hide="false">
-                        <table class="w-full border-collapse">
+                <div class="border border-base-200 rounded-default overflow-x-auto simplebar-horizontal-scrollbar-top dark:border-base-800" data-simplebar data-simplebar-auto-hide="false">
+                    <table class="w-full border-collapse">
+                        {% if fieldsets %}
                             {% for fieldset in fieldsets %}
                                 {% with config_values=fieldset.config_values %}
                                     {% include "admin/constance/includes/results_list.html" %}
                                 {% endwith %}
                             {% endfor %}
+                        {% else %}
+                            {% include "admin/constance/includes/results_list.html" %}
+                        {% endif %}
 
-                            <tfoot>
-                                <tr>
-                                    <td class="border-t border-base-200 px-3 py-2 dark:border-base-800" colspan="100%">
-                                        <div class="flex justify-end">
-                                            {% trans "Save" as title %}
-                                            {% include "unfold/helpers/submit.html" with title=title %}
-                                        </div>
-                                    </td>
-                                </tr>
-                            </tfoot>
-                        </table>
-                    </div>
-                {% else %}
-                    {% include "admin/constance/includes/results_list.html" %}
-                {% endif %}
+                        <tfoot>
+                            <tr>
+                                <td class="border-t border-base-200 px-3 py-2 dark:border-base-800" colspan="100%">
+                                    <div class="flex justify-end">
+                                        {% trans "Save" as title %}
+                                        {% include "unfold/helpers/submit.html" with title=title %}
+                                    </div>
+                                </td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
             </form>
         </div>
     </div>

--- a/src/unfold/contrib/constance/templates/admin/constance/includes/results_list.html
+++ b/src/unfold/contrib/constance/templates/admin/constance/includes/results_list.html
@@ -1,19 +1,21 @@
 {% load admin_list static i18n %}
 
 <tbody {% if fieldset.collapse %} x-data="{ rowsOpen: false }" {% endif %}>
-    <tr {% if fieldset.collapse %} x-on:click="rowsOpen = !rowsOpen" {% endif %} class="{% if fieldset.collapse %}cursor-pointer{% endif %}">
-        <th class="bg-base-50 border-t border-base-200 font-semibold px-3 py-2 text-left text-font-important-light dark:text-font-important-dark dark:border-base-800 dark:bg-white/[.04] {% if forloop.first %}border-t-0{% endif %}" colspan="100%">
-            {{ fieldset.title }}
+    {% if fieldset.title %}
+        <tr {% if fieldset.collapse %} x-on:click="rowsOpen = !rowsOpen" {% endif %} class="{% if fieldset.collapse %}cursor-pointer{% endif %}">
+            <th class="bg-base-50 border-t border-base-200 font-semibold px-3 py-2 text-left text-font-important-light dark:text-font-important-dark dark:border-base-800 dark:bg-white/[.04] {% if forloop.first %}border-t-0{% endif %}" colspan="100%">
+                {{ fieldset.title }}
 
-            {% if fieldset.collapse %}
-                <span class="material-symbols-outlined float-right select-none transition-all" title="{% trans "Collapse" %}" x-bind:class="rowsOpen ? 'rotate-180' : ''">
-                    expand_more
-                </span>
-            {% endif %}
-        </th>
-    </tr>
+                {% if fieldset.collapse %}
+                    <span class="material-symbols-outlined float-right select-none transition-all" title="{% trans "Collapse" %}" x-bind:class="rowsOpen ? 'rotate-180' : ''">
+                        expand_more
+                    </span>
+                {% endif %}
+            </th>
+        </tr>
+    {% endif %}
 
-    <tr class="border-t border-base-200 dark:border-base-800 *:font-semibold *:px-3 *:py-2 *:text-left *:text-font-important-light dark:*:text-font-important-dark" {% if fieldset.collapse %}x-show="rowsOpen"{% endif %}>
+    <tr class="{% if fieldset.title %}border-t{% endif %} border-base-200 dark:border-base-800 *:font-semibold *:px-3 *:py-2 *:text-left *:text-font-important-light dark:*:text-font-important-dark" {% if fieldset.collapse %}x-show="rowsOpen"{% endif %}>
         <th>{% trans "Name" %}</th>
         <th>{% trans "Value" %}</th>
         <th>{% trans "Default" %}</th>


### PR DESCRIPTION
Fixes #1521 

This PR fixes the bug where the Constance admin layout broke when only
CONSTANCE_CONFIG was configured. Missing template tags were added so
both CONSTANCE_CONFIG and CONSTANCE_CONFIG_FIELDSETS render correctly.