### PR TITLE
docs: command dict syntax

### DIFF
--- a/docs/configuration/command.md
+++ b/docs/configuration/command.md
@@ -19,7 +19,7 @@ UNFOLD = {
     # ...
     "COMMAND": {
         "search_models": True,  # Default: False
-        "search_callback": "utils.search_callback"
+        "search_callback": "utils.search_callback",
         "show_history": True,  # Enable history
     },
     # ...


### PR DESCRIPTION
Added comma, when directly copying it was breaking.