### PR TITLE
fix: require pagination formset class for paginated inlines

### DIFF
--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -192,17 +192,21 @@ class ModelAdmin(BaseModelAdminMixin, ActionModelAdminMixin, BaseModelAdmin):
     ) -> dict[str, Any]:
         formset_kwargs = super().get_formset_kwargs(request, obj, inline, prefix)
 
-        if hasattr(inline, "per_page") and inline.per_page:
-            if issubclass(inline.formset, PaginationInlineFormSet) or issubclass(
-                inline.formset, PaginationGenericInlineFormSet
+        if getattr(inline, "per_page", None):
+            if not issubclass(
+                inline.formset,
+                (PaginationInlineFormSet, PaginationGenericInlineFormSet),
             ):
-                formset_kwargs["request"] = request
-                formset_kwargs["per_page"] = inline.per_page
-            else:
                 raise ValueError(
-                    "To use 'per_page' attribute, formset must inherit from "
-                    "'PaginationInlineFormSet' or 'PaginationGenericInlineFormSet'"
+                    "To use 'per_page', formset must inherit from "
+                    "PaginationInlineFormSet or PaginationGenericInlineFormSet"
                 )
+            formset_kwargs.update(
+                {
+                    "request": request,
+                    "per_page": inline.per_page,
+                }
+            )
 
         return formset_kwargs
 


### PR DESCRIPTION
This PR enforces that the class of a formset given to a paginated inline (determined by an inline having the `per_page` prop) is either `PaginationInlineFormSet` or `PaginationGenericInlineFormSet` to avoid users passing the default base django admin formset classes.

Note:

Current behavior still breaks but with an explicit error and explanation how to fix the issue. This is done because simply skipping would lead to no pagination and probable confusion by the user.

fixes: #1402 