### PR TITLE
✨ feat(app.js): Add auto-submit for single select filters in admin ch…

### DIFF
--- a/src/unfold/static/unfold/js/app.js
+++ b/src/unfold/static/unfold/js/app.js
@@ -299,6 +299,33 @@ const filterForm = () => {
       if (value === "") event.formData.delete(key);
     });
   });
+
+  const selectors = [
+    'select[name*="__exact"]',
+    'select[name*="__icontains"]',
+    'select[name*="__in"]',
+    ".admin-autocomplete",
+    ".unfold-admin-autocomplete",
+    "#changelist-filters select"
+  ];
+
+  filterForm.querySelectorAll(selectors.join(", ")).forEach((select) => {
+    if (select.multiple) return;
+
+    select.addEventListener("change", (event) => {
+      const url = new URL(window.location);
+      const params = url.searchParams;
+
+      if (event.target.value) {
+        params.set(event.target.name, event.target.value);
+      } else {
+        params.delete(event.target.name);
+      }
+
+      params.delete("p");
+      window.location.href = url.pathname + "?" + params.toString();
+    });
+  });
 };
 
 /*************************************************************


### PR DESCRIPTION
# Add auto-submit to filter forms

Enhance filter forms to automatically submit when select values change, improving UX consistency with Django admin behavior.

## What changed

- Filter forms now auto-submit when dropdown values change
- Multi-select elements are excluded from auto-submit
- Pagination automatically resets when filters change
- All existing functionality preserved

## Why

Users currently need to manually submit filter forms after selecting values, which breaks the expected workflow compared to standard Django admin filters.

## How

Enhanced the existing `filterForm()` function to add change event listeners to relevant select elements and handle URL parameter updates safely.

**Type**: Enhancement  
**Breaking**: No