### PR TITLE
feat: add template option to display decorator

### DIFF
--- a/src/unfold/decorators.py
+++ b/src/unfold/decorators.py
@@ -106,6 +106,7 @@ def display(
     dropdown: Optional[bool] = None,
     label: Optional[Union[bool, str, dict[str, str]]] = None,
     header: Optional[bool] = None,
+    template: Optional[str] = None,
 ) -> Callable:
     def decorator(func: Callable[[Model], Any]) -> Callable:
         if boolean is not None and empty_value is not None:
@@ -129,6 +130,8 @@ def display(
             func.header = header
         if dropdown is not None:
             func.dropdown = dropdown
+        if template is not None:
+            func.template = template
 
         return func
 

--- a/src/unfold/templatetags/unfold_list.py
+++ b/src/unfold/templatetags/unfold_list.py
@@ -32,6 +32,7 @@ from unfold.utils import (
     display_for_field,
     display_for_header,
     display_for_label,
+    display_for_template,
     display_for_value,
 )
 from unfold.widgets import UnfoldBooleanWidget
@@ -229,6 +230,7 @@ def items_for_result(
                 label = getattr(attr, "label", False)
                 header = getattr(attr, "header", False)
                 dropdown = getattr(attr, "dropdown", False)
+                template = getattr(attr, "template", False)
 
                 if label:
                     result_repr = display_for_label(value, empty_value_display, label)
@@ -238,6 +240,10 @@ def items_for_result(
                     )
                 elif header:
                     result_repr = display_for_header(value, empty_value_display)
+                elif template:
+                    result_repr = display_for_template(
+                        value, empty_value_display, template
+                    )
                 else:
                     result_repr = display_for_value(value, empty_value_display, boolean)
 

--- a/src/unfold/utils.py
+++ b/src/unfold/utils.py
@@ -83,6 +83,24 @@ def display_for_label(value: Any, empty_value_display: str, label: Any) -> SafeT
     )
 
 
+def display_for_template(
+    value: dict, empty_value_display: str, template: str
+) -> SafeText:
+    if not isinstance(value, dict):
+        raise UnfoldException("Display template requires dict")
+
+    context = value or {}
+
+    return mark_safe(
+        render_to_string(
+            template,
+            {
+                **context,
+            },
+        )
+    )
+
+
 def display_for_value(
     value: Any, empty_value_display: str, boolean: bool = False
 ) -> str:


### PR DESCRIPTION
Adds a `template` option to `@display` decorator.

The `template` option expects a Django template, which is rendered with the provided context.

```python
class DemoAdmin(ModelAdmin):
    list_display = [
        "display_template",
    ]

    @display(
        description="Template",
        template="demo/admin/demo_template.html",
    )
    def display_template(self, obj):
        return {
            "name": obj.name,
            "count": obj.related.count(),
        }
``` 

```html
<!-- demo/admin/demo_template.html -->
{{ name }} <sup>{{ count }}</sup>
```

This makes it easier to render arbitrary templates directly through the decorator, without needing to call `render_to_string` in the admin classes.

Would this be helpful?