### PR TITLE
Fix inline add permission check in tabular template and JavaScript

### DIFF
--- a/src/unfold/static/admin/js/inlines.js
+++ b/src/unfold/static/admin/js/inlines.js
@@ -91,6 +91,10 @@
     const addInlineClickHandler = function (e) {
       e.preventDefault();
       const template = $("#" + options.prefix + "-empty");
+      // Check if template exists (has_add_permission check)
+      if (template.length === 0) {
+        return;
+      }
       const row = template.clone(true);
       row
         .removeClass(options.emptyCssClass)
@@ -284,8 +288,12 @@
 
     // Show the add button if allowed to add more items.
     // Note that max_num = None translates to a blank string.
+    // Check if template exists (has_add_permission check)
+    const template = $("#" + options.prefix + "-empty");
+    const hasAddPermission = template.length > 0;
     const showAddButton =
-      maxForms.val() === "" || maxForms.val() - totalForms.val() > 0;
+      hasAddPermission &&
+      (maxForms.val() === "" || maxForms.val() - totalForms.val() > 0);
     if ($this.length && showAddButton) {
       addButton.parent().show();
     } else {

--- a/src/unfold/templates/unfold/helpers/edit_inline/tabular_row.html
+++ b/src/unfold/templates/unfold/helpers/edit_inline/tabular_row.html
@@ -1,4 +1,4 @@
-<tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
+<tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
     {% spaceless %}
         {% for fieldset in inline_admin_form %}
             {% for line in fieldset %}


### PR DESCRIPTION
- Template: Only set id='empty' when has_add_permission is True
- JavaScript: Check template existence before cloning (click handler)
- JavaScript: Check has_add_permission before showing add button
- Align with Django's original tabular.html template behavior
- Prevents users from adding inline items when has_add_permission returns False

Fixes issue where add button was clickable even without permission, causing JavaScript errors when attempting to clone non-existent template.