### PR TITLE
fix: remove `truncate` class to restore dropdown scrollbar visibility

### DIFF
--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -130,7 +130,6 @@ SELECT_CLASSES = [
     "pr-8!",
     "max-w-2xl",
     "appearance-none",
-    "truncate",
 ]
 
 PROSE_CLASSES = [


### PR DESCRIPTION
### Summary
This PR removes the `truncate` class from the default SELECT_CLASSES configuration.   Using `truncate` on a native `<select>` applies `overflow: hidden` and `white-space: nowrap`, which prevents the browser from rendering the scroll bar inside the dropdown list.

### What Was Happening
- When the select menu contained many options, the dropdown would open but **no scrollbar was shown**.
- This behavior came from the `truncate` utility (Tailwind), which is not compatible with native `<select>` elements.

### Fix
- Removed the `truncate` class from SELECT_CLASSES so the dropdown can render normally with scroll support.

### Impact
- Scroll bar now appears correctly when a select widget contains many items.
- No visual regressions in the collapsed select display.