### PR TITLE
fix: use Unfold's boolean icon for readonly fields

### DIFF
--- a/src/unfold/fields.py
+++ b/src/unfold/fields.py
@@ -118,7 +118,7 @@ class UnfoldAdminReadonlyField(helpers.AdminReadonlyField):
             return str(remote_obj)
 
     def _get_contents(self) -> str:
-        from django.contrib.admin.templatetags.admin_list import _boolean_icon
+        from unfold.utils import _boolean_icon
 
         field, obj, model_admin = (
             self.field["field"],


### PR DESCRIPTION
Import _boolean_icon from unfold.utils instead of Django's admin_list templatetags. This ensures readonly boolean fields in change forms display with Unfold's styled icon instead of Django's default icon.

Fixes #1732

Before:
<img width="334" height="130" alt="Screenshot 2025-12-11 at 16 15 17" src="https://github.com/user-attachments/assets/c703b267-7205-4754-b4e9-41da2411f9b4" />

After:
<img width="310" height="127" alt="Screenshot 2025-12-11 at 16 43 23" src="https://github.com/user-attachments/assets/5a80f37f-fadc-45c3-a0d3-dc08e77367fc" />
