### PR TITLE
fix: Center expand icon for collapsed fieldsets (#1798)

### DIFF
--- a/src/unfold/styles.css
+++ b/src/unfold/styles.css
@@ -498,7 +498,7 @@ fieldset details > summary {
 }
 
 fieldset details > summary:after {
-  @apply material-symbols-outlined absolute cursor-pointer right-3 top-3.5;
+  @apply material-symbols-outlined absolute cursor-pointer right-3 top-2.5;
   content: "expand_more";
 }
 


### PR DESCRIPTION
With the current code, the expand icon is weirdly off center:

<img width="956" height="490" alt="2026-01-19-173740_956x490_scrot" src="https://github.com/user-attachments/assets/5be56487-0103-434c-a7c8-bfade0999208" />

This can be fixed by adjusting the top class:

<img width="956" height="490" alt="2026-01-19-173811_956x490_scrot" src="https://github.com/user-attachments/assets/e413089d-1a00-4398-a510-2eac81c5871a" />
