### PR TITLE
fix: related widget mobile overflow

### DIFF
--- a/src/unfold/templates/unfold/widgets/related_widget_wrapper.html
+++ b/src/unfold/templates/unfold/widgets/related_widget_wrapper.html
@@ -8,46 +8,46 @@
             {% spaceless %}
                 {% if not is_hidden %}
                     {% if can_add_related or can_change_related or can_delete_related or can_view_related%}
-                         <div class="flex flex-row gap-2 mt-2 md:mt-0 md:ml-2">
-                        {% if can_change_related %}
-                            <a class="related-widget-wrapper-link change-related bg-white border border-base-200 cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-base-400 text-sm w-[38px] hover:text-base-700 dark:bg-base-900 dark:border-base-700 dark:text-base-500 dark:hover:text-base-200 focus:outline-2 focus:-outline-offset-2 focus:outline-primary-600"
-                               id="change_id_{{ name }}"
-                               data-popup="yes"
-                               data-href-template="{{ change_related_template_url }}?{{ url_params }}"
-                               title="{% blocktranslate %}Change selected {{ model }}{% endblocktranslate %}">
-                                <span class="material-symbols-outlined">edit</span>
-                            </a>
-                        {% endif %}
+                        <div class="flex flex-row gap-2 mt-2 md:mt-0 md:ml-2">
+                            {% if can_change_related %}
+                                <a class="related-widget-wrapper-link change-related bg-white border border-base-200 cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-base-400 text-sm w-[38px] hover:text-base-700 dark:bg-base-900 dark:border-base-700 dark:text-base-500 dark:hover:text-base-200 focus:outline-2 focus:-outline-offset-2 focus:outline-primary-600"
+                                   id="change_id_{{ name }}"
+                                   data-popup="yes"
+                                   data-href-template="{{ change_related_template_url }}?{{ url_params }}"
+                                   title="{% blocktranslate %}Change selected {{ model }}{% endblocktranslate %}">
+                                    <span class="material-symbols-outlined">edit</span>
+                                </a>
+                            {% endif %}
 
-                        {% if can_add_related %}
-                            <a class="related-widget-wrapper-link add-related bg-white border border-base-200  cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-base-400 text-sm w-[38px] hover:text-base-700 dark:bg-base-900 dark:border-base-700 dark:text-base-500 dark:hover:text-base-200 focus:outline-2 focus:-outline-offset-2 focus:outline-primary-600"
-                               data-popup="yes"
-                               id="add_id_{{ name }}"
-                               href="{{ add_related_url }}?{{ url_params }}"
-                               title="{% blocktranslate %}Add another {{ model }}{% endblocktranslate %}">
-                                <span class="material-symbols-outlined">add</span>
-                            </a>
-                        {% endif %}
+                            {% if can_add_related %}
+                                <a class="related-widget-wrapper-link add-related bg-white border border-base-200  cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-base-400 text-sm w-[38px] hover:text-base-700 dark:bg-base-900 dark:border-base-700 dark:text-base-500 dark:hover:text-base-200 focus:outline-2 focus:-outline-offset-2 focus:outline-primary-600"
+                                   data-popup="yes"
+                                   id="add_id_{{ name }}"
+                                   href="{{ add_related_url }}?{{ url_params }}"
+                                   title="{% blocktranslate %}Add another {{ model }}{% endblocktranslate %}">
+                                    <span class="material-symbols-outlined">add</span>
+                                </a>
+                            {% endif %}
 
-                        {% if can_view_related %}
-                            <a class="related-widget-wrapper-link view-related bg-white border border-base-200 cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-base-400 text-sm w-[38px] hover:text-base-700 dark:bg-base-900 dark:border-base-700 dark:text-base-500 dark:hover:text-base-200 focus:outline-2 focus:-outline-offset-2 focus:outline-primary-600"
-                               id="view_id_{{ name }}"
-                               data-href-template="{{ change_related_template_url }}?{{ view_related_url_params }}"
-                               title="{% blocktranslate %}View selected {{ model }}{% endblocktranslate %}">
-                                <span class="material-symbols-outlined">visibility</span>
-                            </a>
-                        {% endif %}
+                            {% if can_view_related %}
+                                <a class="related-widget-wrapper-link view-related bg-white border border-base-200 cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-base-400 text-sm w-[38px] hover:text-base-700 dark:bg-base-900 dark:border-base-700 dark:text-base-500 dark:hover:text-base-200 focus:outline-2 focus:-outline-offset-2 focus:outline-primary-600"
+                                   id="view_id_{{ name }}"
+                                   data-href-template="{{ change_related_template_url }}?{{ view_related_url_params }}"
+                                   title="{% blocktranslate %}View selected {{ model }}{% endblocktranslate %}">
+                                    <span class="material-symbols-outlined">visibility</span>
+                                </a>
+                            {% endif %}
 
-                        {% if can_delete_related %}
-                            <a class="related-widget-wrapper-link delete-related bg-white border border-base-200 cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-red-600 text-sm w-[38px] dark:bg-base-900 dark:border-base-700 dark:text-red-500 focus:outline-2 focus:-outline-offset-2 focus:outline-red-500"
-                               id="delete_id_{{ name }}"
-                               data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
-                               data-popup="yes"
-                               title="{% blocktranslate %}Delete selected {{ model }}{% endblocktranslate %}">
-                                <span class="material-symbols-outlined">delete</span>
-                            </a>
-                        {% endif %}
-                         </div>
+                            {% if can_delete_related %}
+                                <a class="related-widget-wrapper-link delete-related bg-white border border-base-200 cursor-pointer flex items-center h-[38px] justify-center md:ml-2 rounded-default shadow-xs shrink-0 text-red-600 text-sm w-[38px] dark:bg-base-900 dark:border-base-700 dark:text-red-500 focus:outline-2 focus:-outline-offset-2 focus:outline-red-500"
+                                   id="delete_id_{{ name }}"
+                                   data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
+                                   data-popup="yes"
+                                   title="{% blocktranslate %}Delete selected {{ model }}{% endblocktranslate %}">
+                                    <span class="material-symbols-outlined">delete</span>
+                                </a>
+                            {% endif %}
+                        </div>
                     {% endif %}
                 {% endif %}
             {% endspaceless %}


### PR DESCRIPTION
On mobile:
<img width="417" height="136" alt="image" src="https://github.com/user-attachments/assets/e247df57-97a7-49f1-80c1-6983b69ec63e" />

On tablet and up - unchanged:
<img width="751" height="99" alt="image" src="https://github.com/user-attachments/assets/5d99f94b-7a02-4808-bd5b-a3cb524462ad" />
