### PR TITLE
fix: SimpleListFilter reset after submittion

### DIFF
--- a/src/unfold/templates/admin/filter.html
+++ b/src/unfold/templates/admin/filter.html
@@ -5,6 +5,10 @@
         {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
     </h3>
 
+    {% if spec.value %}
+        <input type="hidden" name="{{ spec.parameter_name }}" value="{{ spec.value }}">
+    {% endif %}
+
     {% for choice in choices %}
         {% if choice.selected and spec.lookup_val.0 %}
             <input type="hidden" name="{{ spec.lookup_kwarg }}" value="{{ spec.lookup_val.0 }}" />


### PR DESCRIPTION
When creating a custom filter by inheriting the SimpleListFilter filter from f"rom django.contrib.admin import SimpleListFilter", a filter is created that does not contain inputs. Because of this, when you click on the "Apply filters" button, the parameter set via SimpleListFilter is reset. To solve this, I suggest adding a hidden input field that will be processed correctly and will not reset the filter.