### PR TITLE
fix: remove admin-autocomplete class from dropdown filter widget

### DIFF
--- a/src/unfold/contrib/filters/forms.py
+++ b/src/unfold/contrib/filters/forms.py
@@ -118,7 +118,7 @@ class DropdownForm(forms.Form):
     widget = UnfoldAdminSelectWidget(
         attrs={
             "data-theme": "admin-autocomplete",
-            "class": "unfold-admin-autocomplete admin-autocomplete",
+            "class": "unfold-admin-autocomplete",
         }
     )
     field = ChoiceField
@@ -138,7 +138,7 @@ class DropdownForm(forms.Form):
             self.widget = UnfoldAdminSelectMultipleWidget(
                 attrs={
                     "data-theme": "admin-autocomplete",
-                    "class": "unfold-admin-autocomplete admin-autocomplete",
+                    "class": "unfold-admin-autocomplete",
                 }
             )
             self.field = MultipleChoiceField


### PR DESCRIPTION
## Summary

Remove `admin-autocomplete` CSS class from DropdownForm widget attrs to prevent Django's autocomplete.js from hijacking the filter's Select2 when autocomplete_fields + list_editable are used together.

## Root Cause

When autocomplete_fields is set, Django loads autocomplete.js which initializes all .admin-autocomplete elements as AJAX Select2 widgets. The dropdown filter had this class, so it got reinitialized pointing to the wrong endpoint, resulting in empty filter results.

AutocompleteSelectFilter was unaffected because it uses unfold-filter-autocomplete class instead.

## Changes

src/unfold/contrib/filters/forms.py — removed admin-autocomplete from widget class attr (lines 121, 141), keeping only unfold-admin-autocomplete. Safe because:

- select2.init.js targets .unfold-admin-autocomplete (preserved)
- Select2 theme uses data-theme="admin-autocomplete" attribute (preserved)
- Autocomplete widgets in widgets.py are unaffected

## Test plan

- [x] pytest tests/test_filters.py — 103 passed
- [x] pytest tests/ — 320 passed, 90% coverage
- [ ] Manual: verify filter dropdown works with autocomplete_fields + list_editable

Closes #1633