### PR TITLE
fix: tabs_primary_active crashes with 'str has no attribute opts' on non-changeform views

### DIFF
--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -896,6 +896,9 @@ def tabs_errors_count(fieldset: Fieldset) -> int:
 def tabs_primary_active(inlines: list[InlineAdminFormSet]) -> str:
     active = "general"
 
+    if not isinstance(inlines, list):
+        return active
+
     for inline in inlines:
         if getattr(inline.opts, "tab", False) and inline.formset.errors:
             for error in inline.formset.errors:


### PR DESCRIPTION
When `inline_admin_formsets` is not in the template context on changelist/custom pages, django resolves it as `""`

It was introduced in 0.77.0