### PR TITLE
Add `filter_title` block to `admin/filter.html`

### DIFF
--- a/src/unfold/templates/admin/filter.html
+++ b/src/unfold/templates/admin/filter.html
@@ -2,7 +2,9 @@
 
 <div>
     <h3 class="font-semibold mb-2 text-font-important-light dark:text-font-important-dark">
-        {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+        {% block filter_title %}
+            {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+        {% endblock %}
     </h3>
 
     {% for choice in choices %}


### PR DESCRIPTION
Add `filter_title` block to `admin/filter.html` (allows overriding the "By ..." prefix without copying full template)

No behavior change by default.