### PR TITLE
Add 'f' shortcut to open changelist filters

### DIFF
--- a/src/unfold/static/unfold/js/app.js
+++ b/src/unfold/static/unfold/js/app.js
@@ -181,6 +181,28 @@ const moveRecords = (e) => {
 };
 
 /*************************************************************
+ * Change list filters
+ *************************************************************/
+function changeList(hasFilters = false) {
+  return {
+    hasFilters,
+    filterOpen: false,
+    applyShortcut(event) {
+      if (
+        this.hasFilters &&
+        event.key.toLowerCase() === "f" &&
+        document.activeElement.tagName.toLowerCase() !== "input" &&
+        document.activeElement.tagName.toLowerCase() !== "textarea" &&
+        !document.activeElement.isContentEditable
+      ) {
+        event.preventDefault();
+        this.filterOpen = true;
+      }
+    },
+  };
+}
+
+/*************************************************************
  * Search form
  *************************************************************/
 function searchForm() {

--- a/src/unfold/templates/admin/change_list.html
+++ b/src/unfold/templates/admin/change_list.html
@@ -33,7 +33,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="content-main" x-data="{ filterOpen: false }">
+    <div id="content-main" x-data="changeList({% if cl.has_filters %}true{% else %}false{% endif %})" x-on:keydown.window="applyShortcut($event)" x-on:keydown.escape.window="filterOpen = false">
         {% if cl.formset and cl.formset.errors %}
             {% include "unfold/helpers/messages/errornote.html" with errors=cl.formset.errors %}
 
@@ -61,8 +61,10 @@
 
                             {% block filters %}
                                 {% if cl.has_filters %}
-                                    <a class="{% if cl.has_active_filters %}bg-primary-600 border-primary-600 text-white{% else %}bg-white border-base-200 hover:text-primary-600 dark:bg-base-900 dark:border-base-700 dark:hover:text-primary-500{% endif %} border cursor-pointer flex font-medium gap-2 group items-center px-3 py-2 rounded-default shadow-xs text-sm lg:ml-auto md:mt-0 {% if not cl.model_admin.list_filter_sheet %}2xl:hidden{% endif %}" x-on:click="filterOpen = true" x-on:keydown.escape.window="filterOpen = false">
+                                    <a class="{% if cl.has_active_filters %}bg-primary-600 border-primary-600 text-white{% else %}bg-white border-base-200 hover:text-primary-600 dark:bg-base-900 dark:border-base-700 dark:hover:text-primary-500{% endif %} border cursor-pointer flex font-medium gap-2 group items-center px-3 py-2 rounded-default shadow-xs text-sm lg:ml-auto md:mt-0 {% if not cl.model_admin.list_filter_sheet %}2xl:hidden{% endif %}" x-on:click="filterOpen = true">
                                         {% trans "Filters" %}
+
+                                        {% include "unfold/helpers/shortcut.html" with shortcut="f" %}
 
                                         <span class="material-symbols-outlined md-18 ml-auto">filter_list</span>
                                     </a>


### PR DESCRIPTION
**Description**
This PR adds a keyboard shortcut on changelist pages to open the filters panel.

**Changes**
- Added a `changeList()` Alpine helper in `src/unfold/static/unfold/js/app.js`
- Added an `f` shortcut to open filters
  - works case-insensitively
  - ignored when typing in inputs, textareas, or contenteditable elements
  - only active when filters are available (`cl.has_filters`)
- Wired the changelist root container to `changeList(...)` in `src/unfold/templates/admin/change_list.html`
- Added an `f` shortcut hint next to the Filters button
- Kept existing `Esc` behavior for closing filters

**Why**
- Makes filters quicker to open on changelist pages
- Keeps shortcut behavior aligned with existing shortcuts like `t` for search

**Notes**
- Only applies to changelist filters
- No changes outside changelist pages

<img width="364" height="181" alt="image" src="https://github.com/user-attachments/assets/6e7a88ae-8408-42c3-b104-5b66e50a94d9" />