### PR TITLE
fix: center and prevent repetition of user avatars

### DIFF
--- a/src/unfold/templates/unfold/helpers/avatar.html
+++ b/src/unfold/templates/unfold/helpers/avatar.html
@@ -1,5 +1,5 @@
 {% with avatar_url=user.avatar_url %}
-    <div class="bg-base-200 bg-cover font-semibold flex items-center justify-center relative select-none text-important dark:bg-base-700 after:absolute after:inset-0 after:inset-ring after:inset-ring-base-800/10 dark:after:inset-ring-base-200/10
+    <div class="bg-base-200 bg-cover bg-no-repeat bg-center font-semibold flex items-center justify-center relative select-none text-important dark:bg-base-700 after:absolute after:inset-0 after:inset-ring after:inset-ring-base-800/10 dark:after:inset-ring-base-200/10
                 {% if size == "md" %}
                     h-[34px] min-w-[34px] w-[34px]
                 {% elif size == "sm" %}


### PR DESCRIPTION
## Summary

**Improved the avatar rendering logic in the navigation bar.**

Previously, the avatar container used **bg-cover** *only* but lacked properties to handle non-square images correctly resulting in off-center profile pictures.

## Changes:
- Added bg-center to ensure the subject of the photo remains focused in the center of the avatar circle.
- Added bg-no-repeat to prevent image tiling.

## Visual Comparison
**Before:** <img width="615" height="998" alt="Screenshot 2026-05-11 at 04-24-55 29 l Change user Django site admin" src="https://github.com/user-attachments/assets/77b4433f-0ff1-44c1-8ca3-366e33d9f094" />

**After:**  <img width="615" height="998" alt="Screenshot 2026-05-11 at 04-24-35 29 l Change user Django site admin" src="https://github.com/user-attachments/assets/35845886-09b6-4f50-9985-2fd06692a3f0" />

## Test plan
1. Added a profile_pic field and a custom property avatar_url to the User model (only for testing, not commited).
2. Uploaded a wide landscape image as a profile picture.
3. Verified the navbar avatar centers on the middle of the image instead of the bottom-left corner.

## Use of AI
Nope!





