### PR TITLE
`fieldset_row_classes`: Clean up handling of missing `line` in context

### DIFF
--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -395,7 +395,7 @@ def fieldset_row_classes(context: RequestContext) -> str:
     ]
 
     formset = context.get("inline_admin_formset", None)
-    line = context.get("line") or []
+    line = context.get("line", [])
 
     # Hide the field in case of ordering field for sorting
     for field in line:
@@ -407,7 +407,7 @@ def fieldset_row_classes(context: RequestContext) -> str:
         ):
             classes.append("hidden")
 
-    if len(line.fields) > 1:
+    if line and len(line.fields) > 1:
         classes.extend(
             [
                 "grid",
@@ -415,7 +415,7 @@ def fieldset_row_classes(context: RequestContext) -> str:
             ]
         )
 
-    if not line.has_visible_field:
+    if line and not line.has_visible_field:
         classes.append("hidden")
 
     return " ".join(set(classes))


### PR DESCRIPTION
## Summary

Use more direct default setting in `fieldset_row_classes` method, and make the whole method work when it's the default.  See https://github.com/unfoldadmin/django-unfold/pull/2065#issuecomment-4622368261 for more details.

## Test plan

Honestly, just did local testing.

## Use of AI

None.