### PR TITLE
Add migrate step to testing server instructions

### DIFF
--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -7,7 +7,7 @@ order: 12
 
 ## Starting the testing server
 
-The Unfold repository contains a testing server that you can use to test any changes you make to the code. To start the server, navigate to `tests/server` and run `uv run -- python manage.py runserver`. This will start the server at `http://localhost:8000`.
+The Unfold repository contains a testing server that you can use to test any changes you make to the code. To start the server, navigate to `tests/server` and run `uv run -- python manage.py migrate --skip-checks` then `uv run -- python manage.py runserver`. This will start the server at `http://localhost:8000`.
 
 Before running the server, you don't need to install anything, as `uv` will automatically take care of the dependencies.
 


### PR DESCRIPTION
## Summary

The instructions for running the testing server in the Development documentation is missing the migrate step.  This adds that.

## Test plan

https://discord.com/channels/1297493955231088650/1297493955864301600/1512440040733540362

## Use of AI

None!
