### PR TITLE
Add migrate step to testing server instructions

### DIFF
--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -7,7 +7,7 @@ order: 12
 
 ## Starting the testing server
 
-The Unfold repository contains a testing server that you can use to test any changes you make to the code. To start the server, navigate to `tests/server` and run `uv run -- python manage.py runserver`. This will start the server at `http://localhost:8000`.
+The Unfold repository contains a testing server that you can use to test any changes you make to the code. To start the server, navigate to `tests/server` and run `uv run -- python manage.py migrate` then `uv run -- python manage.py runserver`. This will start the server at `http://localhost:8000`.
 
 Before running the server, you don't need to install anything, as `uv` will automatically take care of the dependencies.
 


### PR DESCRIPTION
## Summary

Adds needed step to instructions for setting up the development test server.

## Test plan

If you follow the existing instructions, you'll see a warning about missing tables and migrations.  After you run migrate it'll work.

## Use of AI

None!