### PR TITLE
chore: typing of translation strings in decorators

### DIFF
--- a/src/unfold/decorators.py
+++ b/src/unfold/decorators.py
@@ -8,6 +8,7 @@ from django.db.models import Model
 from django.db.models.expressions import BaseExpression, Combinable
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
+from django_stubs_ext import StrOrPromise
 
 from unfold.dataclasses import Action, ActionDialog
 from unfold.enums import ActionVariant
@@ -18,7 +19,7 @@ def action(
     function: Callable | None = None,
     *,
     permissions: Iterable[str] | None = None,
-    description: str | None = None,
+    description: StrOrPromise | None = None,
     url_path: str | None = None,
     attrs: dict[str, Any] | None = None,
     icon: str | None = None,
@@ -137,10 +138,10 @@ def display(
     boolean: bool | None = None,
     image: bool | None = None,
     ordering: str | Combinable | BaseExpression | None = None,
-    description: str | Any | None = None,
+    description: StrOrPromise | Any | None = None,
     empty_value: str | None = None,
     dropdown: bool | None = None,
-    label: bool | str | dict[str, str] | None = None,
+    label: bool | StrOrPromise | dict[str, str] | None = None,
     header: bool | None = None,
     wrapper_class: str | None = None,
 ) -> Callable:

--- a/src/unfold/decorators.py
+++ b/src/unfold/decorators.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterable
 from functools import wraps
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.contrib.admin.options import BaseModelAdmin
 from django.core.exceptions import PermissionDenied
@@ -8,7 +8,9 @@ from django.db.models import Model
 from django.db.models.expressions import BaseExpression, Combinable
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
-from django_stubs_ext import StrOrPromise
+
+if TYPE_CHECKING:
+    from django_stubs_ext import StrOrPromise
 
 from unfold.dataclasses import Action, ActionDialog
 from unfold.enums import ActionVariant
@@ -19,7 +21,7 @@ def action(
     function: Callable | None = None,
     *,
     permissions: Iterable[str] | None = None,
-    description: StrOrPromise | None = None,
+    description: "StrOrPromise | None" = None,
     url_path: str | None = None,
     attrs: dict[str, Any] | None = None,
     icon: str | None = None,
@@ -138,10 +140,10 @@ def display(
     boolean: bool | None = None,
     image: bool | None = None,
     ordering: str | Combinable | BaseExpression | None = None,
-    description: StrOrPromise | Any | None = None,
+    description: "StrOrPromise | Any | None" = None,
     empty_value: str | None = None,
     dropdown: bool | None = None,
-    label: bool | StrOrPromise | dict[str, str] | None = None,
+    label: "bool | StrOrPromise | dict[str, str] | None" = None,
     header: bool | None = None,
     wrapper_class: str | None = None,
 ) -> Callable:


### PR DESCRIPTION
## Summary

Currently, the `action` and `display` decorators expect a `str` for the description argument. However, the description is often provided as a translated string with `gettext_lazy()`. This leads to type warnings, like the following in the PyCharm IDE:

<img width="895" height="225" alt="grafik" src="https://github.com/user-attachments/assets/a5ee2e26-96c9-4630-b358-996ccc011673" />


This PR replaces the type hint `str` with `StrOrPromise` from `django_stubs_ext` to allow `_StrPromise` for the `description` and `label` arguments of the decorators.

## Test plan

I tested it in our actual project, which uses the decorator as such:

```
from django.utils.translation import gettext_lazy as _
[...]
@action(
        description=_("Export"),
        permissions=["geno.canview_member"],
        icon="download",
    )
```
There is no warning anymore and the type hint is correct:

<img width="829" height="187" alt="grafik" src="https://github.com/user-attachments/assets/c6f5f6ee-fbcf-4c80-8889-23c8d950a63f" />

Also, I ran the standard test suite of the django-unfold project.

## Use of AI

I did not use any AI tools for this PR.

