### PR TITLE
fix: Use request.user to not collide with user context on other views

### DIFF
--- a/src/unfold/templates/unfold/helpers/navigation_user.html
+++ b/src/unfold/templates/unfold/helpers/navigation_user.html
@@ -16,12 +16,12 @@
 
         <div class="flex flex-col select-none min-w-0">
             <div class="font-semibold text-important tracking-tight truncate">
-                {{ user.get_full_name|default:user.get_username }}
+                {{ request.user.get_full_name|default:request.user.get_username }}
             </div>
 
-            {% if user.email %}
+            {% if request.user.email %}
                 <div class="text-subtle text-xs truncate">
-                    {{ user.email }}
+                    {{ request.user.email }}
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
## Summary

When a view is loading a `user` into the context, it also affects the rendering of the user information in the navigation. The avatar already correctly uses `request.user`. 

## Test plan

Haven't tested it

## Use of AI

It helped me find out the potential issue. I manually changed the few lines though.