### PR TITLE
empty_results helper suggests actions even when not allowed

### DIFF
--- a/src/unfold/templates/unfold/helpers/empty_results.html
+++ b/src/unfold/templates/unfold/helpers/empty_results.html
@@ -34,8 +34,8 @@
             {% endif %}
         </div>
     {% else %}
-    <p class="mb-6 text-center">
-        {% trans "This page yielded into no results." %}
-    </p>
+        <p class="mb-6 text-center">
+            {% trans "This page yielded into no results." %}
+        </p>
     {% endif %}
 </div>

--- a/src/unfold/templates/unfold/helpers/empty_results.html
+++ b/src/unfold/templates/unfold/helpers/empty_results.html
@@ -14,11 +14,11 @@
         {% trans "No results found" %}
     </h2>
 
-    <p class="mb-6 text-center">
-        {% trans "This page yielded into no results. Create a new item or reset your filters." %}
-    </p>
+    {% if has_add_permission or cl.has_filters or cl.query %}
+        <p class="mb-6 text-center">
+            {% trans "This page yielded into no results. Create a new item or reset your filters." %}
+        </p>
 
-    {% if has_add_permission or cl.has_filters %}
         <div class="flex flex-col gap-4 justify-center w-full lg:flex-row">
             {% if has_add_permission %}
                 <a href="{% add_preserved_filters add_url is_popup to_field %}" class="bg-primary-600 flex flex-row font-medium gap-2 items-center h-[38px] justify-center px-3 py-2 rounded-default text-white w-full lg:w-auto">
@@ -33,5 +33,9 @@
                 </a>
             {% endif %}
         </div>
+    {% else %}
+    <p class="mb-6 text-center">
+        {% trans "This page yielded into no results." %}
+    </p>
     {% endif %}
 </div>


### PR DESCRIPTION
## Summary

Right now when there are no results, there's a message suggesting to `Create a new item or reset your filters` even when neither of those options aren't being presented below.

This strips that sentence from the message if no actions are available.

## Test plan

<!-- Describe how exactly you tested the changes. -->

## Use of AI

None
