### PR TITLE
fix: bypass error checking for initial migration process

### DIFF
--- a/src/unfold/checks.py
+++ b/src/unfold/checks.py
@@ -5,6 +5,7 @@ from django.contrib.admin.options import BaseModelAdmin
 from django.contrib.auth.models import Permission
 from django.core import checks
 from django.core.checks import CheckMessage
+from django.db import OperationalError, ProgrammingError
 
 from unfold.dataclasses import UnfoldAction
 
@@ -37,13 +38,18 @@ class UnfoldModelAdminChecks(ModelAdminChecks):
                 if "." in permission:
                     app_label, codename = permission.split(".")
 
-                    if not Permission.objects.filter(
-                        content_type__app_label=app_label,
-                        codename=codename,
-                    ).exists():
+                    try:
+                        exists = Permission.objects.filter(
+                            content_type__app_label=app_label,
+                            codename=codename,
+                        ).exists()
+                    except (OperationalError, ProgrammingError):
+                        continue
+
+                    if not exists:
                         errors.append(
                             checks.Error(
-                                f"@action decorator on {action.method.original_function_name}() in class {obj.__class__.__name__} specifies permission {permission} which does not exists.",  # type: ignore
+                                f"@action decorator on {action.method.original_function_name}() in class {obj.__class__.__name__} specifies permission {permission} which does not exists.",
                                 obj=obj.__class__,
                                 id="admin.E129",
                             )


### PR DESCRIPTION
<!--
Before creating a pull request, make sure all questions below are properly answered.
-->

## Summary
When attempting to test the available dev-server within the repo via `uv run -- python manage.py runserver`, Django returns the following error message: `django.db.utils.OperationalError: no such table: auth_permission`. Attempting to run `python manage.py migrate` before `runserver` leads to the same issue.

Currently, the only way to overcome this is to run the `migrate` command with the `--skip-checks` flag included.

To ensure consistency with the listed documentation, the fix implements a `try/except` bypass within `src/unfold/checks.py` to ensure developers can have an easy installation process for the repo on their device.

## Test plan

OS: Sequoia 15.7.1
Python Version: 3.12.2
Django Version: 5.2.14

1. The created `db.sqlite3` within `tests/server` is deleted to ensure a fresh installation.
2. Run `uv run -- python manage.py migrate` to check if the code change is met.
3. From the root folder, `uv run -- pytest .` was run to ensure the changes do not break anything else, with the tests executed from my end having shown `417 passed in 19.74s` with a total coverage of `95.75%`.

<!-- Describe how exactly you tested the changes. -->

## Use of AI

- AI was not written for this pull request, but the code generated was written by AI through Claude Code in order to identify the reason as to why the listed instructions under `docs/development/index.md` could not be followed through properly.
- The generated code was not modified or updated afterwards.
