### PR TITLE
Fix typo: `Dsable` -> `Disable` in ModelAdmin docs

### DIFF
--- a/docs/configuration/modeladmin.md
+++ b/docs/configuration/modeladmin.md
@@ -56,7 +56,7 @@ class CustomAdminClass(ModelAdmin):
     # Position horizontal scrollbar in changelist at the top
     list_horizontal_scrollbar_top = False
 
-    # Dsable select all action in changelist
+    # Disable select all action in changelist
     list_disable_select_all = False
 
     # Custom actions


### PR DESCRIPTION
## Summary

Corrects spelling of `Disable` in the [ModelAdmin options documentation](https://github.com/unfoldadmin/django-unfold/blob/92f9aa7c775d2ecbdc637828c0ff64582edcb82b/docs/configuration/modeladmin.md)

## Use of AI

None