### PR TITLE
fix: prevent conditional fields from collapsing multi widgets

### DIFF
--- a/docs/configuration/conditional-fields.md
+++ b/docs/configuration/conditional-fields.md
@@ -45,13 +45,13 @@ The `conditional_fields` dictionary uses a straightforward key-value structure:
 
 When a user interacts with your form, Django Unfold evaluates these expressions in real-time, showing or hiding fields accordingly. This creates a responsive, interactive experience without requiring page reloads.
 
-For fields rendered with a fixed-subwidget `MultiWidget` (such as split date-time, money, or integer range widgets), 
+For fields rendered with a fixed-subwidget `MultiWidget` (such as split date-time, money, or integer range widgets),
 Django Unfold automatically handles the complexity by assigning numeric suffixes to each widget component. For example,
 a date-time field named `date_start` would have its widgets accessible as `date_start_0` and `date_start_1` in your
 conditional expressions.
 
 > **Note on dynamic multi-widgets.** Widgets whose inputs are added/removed dynamically or share a single name — most
-> notably the `ArrayWidget` — cannot act as a condition *source*. A single Alpine binding would be copied onto every 
+> notably the `ArrayWidget` — cannot act as a condition *source*. A single Alpine binding would be copied onto every
 > input and collapse the field's value, so Unfold safely skips binding them. Such fields still work as condition
 > *targets* (they can be shown or hidden by other fields' conditions). If you build a custom `MultiWidget` whose
 > subwidgets are fixed and have distinct names, you can opt it into per-item bindings by setting

--- a/docs/configuration/conditional-fields.md
+++ b/docs/configuration/conditional-fields.md
@@ -45,7 +45,17 @@ The `conditional_fields` dictionary uses a straightforward key-value structure:
 
 When a user interacts with your form, Django Unfold evaluates these expressions in real-time, showing or hiding fields accordingly. This creates a responsive, interactive experience without requiring page reloads.
 
-For fields that use multiple widgets (like SplitDateTimeField), Django Unfold automatically handles the complexity by assigning numeric suffixes to each widget component. For example, a date-time field named `date_start` would have its widgets accessible as `date_start_0` and `date_start_1` in your conditional expressions.
+For fields rendered with a fixed-subwidget `MultiWidget` (such as split date-time, money, or integer range widgets), 
+Django Unfold automatically handles the complexity by assigning numeric suffixes to each widget component. For example,
+a date-time field named `date_start` would have its widgets accessible as `date_start_0` and `date_start_1` in your
+conditional expressions.
+
+> **Note on dynamic multi-widgets.** Widgets whose inputs are added/removed dynamically or share a single name — most
+> notably the `ArrayWidget` — cannot act as a condition *source*. A single Alpine binding would be copied onto every 
+> input and collapse the field's value, so Unfold safely skips binding them. Such fields still work as condition
+> *targets* (they can be shown or hidden by other fields' conditions). If you build a custom `MultiWidget` whose
+> subwidgets are fixed and have distinct names, you can opt it into per-item bindings by setting
+> `supports_conditional_per_item = True` on the widget class.
 
 This approach is particularly useful for complex forms where certain information is only relevant based on specific user choices, helping to reduce visual clutter and guide users through your interface more effectively.
 

--- a/docs/widgets/array.md
+++ b/docs/widgets/array.md
@@ -52,3 +52,10 @@ class CustomAdminClass(ModelAdmin):
         form.base_fields["array_field"].widget = ArrayWidget(choices=SomeChoices)
         return form
 ```
+
+## Conditional fields
+
+`ArrayWidget` renders a dynamic list of inputs that all share the field name, so it cannot be used as a *source* in
+[conditional fields](/docs/configuration/conditional-fields/) — a single Alpine binding would be copied onto every
+input and collapse the array to its first value. Unfold therefore skips binding it, and no extra configuration is
+needed. An array field can still be a conditional *target*: it can be shown or hidden based on another field's value.

--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -17,6 +17,7 @@ from django.core.paginator import Paginator
 from django.db.models import Model
 from django.db.models.options import Options
 from django.forms import BoundField, CheckboxSelectMultiple
+from django.forms.widgets import MultiWidget, Widget
 from django.http import HttpRequest, QueryDict
 from django.template import Context, Library, Node, RequestContext, TemplateSyntaxError
 from django.template.base import NodeList, Parser, Token, token_kwargs
@@ -31,11 +32,7 @@ from unfold.components import ComponentRegistry
 from unfold.enums import ActionVariant
 from unfold.sections import BaseSection
 from unfold.utils import prettify_traceback
-from unfold.widgets import (
-    UnfoldAdminMoneyWidget,
-    UnfoldAdminSelect2Widget,
-    UnfoldAdminSplitDateTimeWidget,
-)
+from unfold.widgets import UnfoldAdminSelect2Widget
 
 register = Library()
 
@@ -54,6 +51,10 @@ def _count_errors_in_general(
                     count += 1
 
     return count
+
+
+def _supports_conditional_per_item(widget: Widget) -> bool:
+    return getattr(widget, "supports_conditional_per_item", False)
 
 
 def _count_errors_in_inline(inline: InlineAdminFormSet) -> int:
@@ -550,13 +551,12 @@ def changeform_data(adminform: AdminForm) -> str:
                 if isinstance(field.field, dict):
                     continue
 
-                if isinstance(
-                    field.field.field.widget, UnfoldAdminSplitDateTimeWidget
-                ) or isinstance(field.field.field.widget, UnfoldAdminMoneyWidget):
-                    for index, _widget in enumerate(field.field.field.widget.widgets):
-                        fields[
-                            f"{field.field.name}{field.field.field.widget.widgets_names[index]}"
-                        ] = None
+                if isinstance(field.field.field.widget, MultiWidget):
+                    if _supports_conditional_per_item(field.field.field.widget):
+                        for index, _widget in enumerate(field.field.field.widget.widgets):
+                            fields[
+                                f"{field.field.name}{field.field.field.widget.widgets_names[index]}"
+                            ] = None
                 elif isinstance(field.field.field.widget, CheckboxSelectMultiple):
                     fields[field.field.name] = []
                 else:
@@ -580,15 +580,14 @@ def changeform_condition(field: AdminField) -> AdminField:
         field.field.field.widget.attrs["x-init"] = mark_safe(
             f"const $ = django.jQuery; $(function () {{ const select = $('#{field.field.auto_id}'); select.on('change', (ev) => {{ {field.field.name} = select.val(); }}); }});"
         )
-    elif isinstance(
-        field.field.field.widget, UnfoldAdminSplitDateTimeWidget
-    ) or isinstance(field.field.field.widget, UnfoldAdminMoneyWidget):
-        for index, widget in enumerate(field.field.field.widget.widgets):
-            field_name = (
-                f"{field.field.name}{field.field.field.widget.widgets_names[index]}"
-            )
+    elif isinstance(field.field.field.widget, MultiWidget):
+        if _supports_conditional_per_item(field.field.field.widget):
+            for index, widget in enumerate(field.field.field.widget.widgets):
+                field_name = (
+                    f"{field.field.name}{field.field.field.widget.widgets_names[index]}"
+                )
 
-            widget.attrs["x-model.fill"] = field_name
+                widget.attrs["x-model.fill"] = field_name
     else:
         field.field.field.widget.attrs["x-model.fill"] = field.field.name
 

--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -553,7 +553,9 @@ def changeform_data(adminform: AdminForm) -> str:
 
                 if isinstance(field.field.field.widget, MultiWidget):
                     if _supports_conditional_per_item(field.field.field.widget):
-                        for index, _widget in enumerate(field.field.field.widget.widgets):
+                        for index, _widget in enumerate(
+                            field.field.field.widget.widgets
+                        ):
                             fields[
                                 f"{field.field.name}{field.field.field.widget.widgets_names[index]}"
                             ] = None

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -380,6 +380,7 @@ class UnfoldAdminUUIDInputWidget(AdminUUIDInputWidget):
 
 class UnfoldAdminIntegerRangeWidget(MultiWidget):
     template_name = "unfold/widgets/range.html"
+    supports_conditional_per_item = True
 
     def __init__(self, attrs: dict[str, Any] | None = None) -> None:
         attrs = attrs or {}
@@ -582,6 +583,7 @@ class UnfoldAdminExpandableTextareaWidget(UnfoldAdminTextareaWidget):
 
 class UnfoldAdminSplitDateTimeWidget(AdminSplitDateTime):
     template_name = "unfold/widgets/split_datetime.html"
+    supports_conditional_per_item = True
 
     def __init__(self, attrs: dict[str, Any] | None = None) -> None:
         widgets = [
@@ -600,6 +602,7 @@ class UnfoldAdminSplitDateTimeWidget(AdminSplitDateTime):
 
 class UnfoldAdminSplitDateTimeVerticalWidget(AdminSplitDateTime):
     template_name = "unfold/widgets/split_datetime_vertical.html"
+    supports_conditional_per_item = True
 
     def __init__(
         self,
@@ -954,6 +957,7 @@ try:
 
     class UnfoldAdminMoneyWidget(MoneyWidget):
         template_name = "unfold/widgets/split_money.html"
+        supports_conditional_per_item = True
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             attrs = {}

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -674,6 +674,7 @@ def test_tags_changeform_data_skips_unflagged_multiwidget(rf):
     changeform_condition, so changeform_data must not declare a scope variable
     for it either — otherwise the x-data object carries a dead key.
     """
+
     class CustomMultiWidget(forms.MultiWidget):
         def __init__(self, attrs=None):
             super().__init__([forms.TextInput(), forms.TextInput()], attrs)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 
 import pytest
 from django import forms
-from django.contrib.admin.helpers import AdminField
+from django.contrib.admin.helpers import AdminField, AdminForm
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
@@ -17,10 +17,16 @@ from example.admin import ProjectDataset, UserAdmin
 from example.models import User
 
 from unfold.components import BaseComponent, register_component
+from unfold.contrib.forms.widgets import ArrayWidget
 from unfold.enums import ActionVariant
 from unfold.fields import UnfoldAdminField, UnfoldAdminReadonlyField
 from unfold.sites import UnfoldAdminSite
 from unfold.views import ChangeList
+from unfold.widgets import (
+    UnfoldAdminIntegerRangeWidget,
+    UnfoldAdminSplitDateTimeVerticalWidget,
+    UnfoldAdminTextInputWidget,
+)
 
 
 @pytest.mark.django_db
@@ -662,6 +668,38 @@ def test_tags_changeform_data(rf, user_factory):
     assert '"username": null' in response
 
 
+def test_tags_changeform_data_skips_unflagged_multiwidget(rf):
+    """
+    A MultiWidget that does not opt into per-item bindings is skipped by
+    changeform_condition, so changeform_data must not declare a scope variable
+    for it either — otherwise the x-data object carries a dead key.
+    """
+    class CustomMultiWidget(forms.MultiWidget):
+        def __init__(self, attrs=None):
+            super().__init__([forms.TextInput(), forms.TextInput()], attrs)
+
+        def decompress(self, value):
+            return [None, None]
+
+    class DataForm(forms.Form):
+        title = forms.CharField()
+        combo = forms.Field(widget=CustomMultiWidget(), required=False)
+
+    admin_form = AdminForm(DataForm(), [(None, {"fields": ["title", "combo"]})], {})
+
+    response = Template("{% load unfold %} {{ adminform|changeform_data }}").render(
+        RequestContext(
+            rf.get("/"),
+            {
+                "adminform": admin_form,
+            },
+        )
+    )
+
+    assert '"title": null' in response
+    assert "combo" not in response
+
+
 @pytest.mark.django_db
 def test_tags_changeform_condition_field(rf):
     form = UserAdmin(User, UnfoldAdminSite()).get_form(None)()
@@ -767,6 +805,92 @@ def test_tags_changeform_condition_readonly_field(rf, user_factory):
 
     assert "Custom readonly field" in response
     assert "readonly" in response
+
+
+def test_tags_changeform_condition_field_array(rf):
+    class ArrayForm(forms.Form):
+        authors = forms.CharField(
+            widget=ArrayWidget(widget_class=UnfoldAdminTextInputWidget)
+        )
+
+    form = ArrayForm(initial={"authors": ["Thomas", "Fari", "Richard"]})
+    admin_field = AdminField(form, "authors", False)
+
+    response = Template(
+        "{% load unfold %} {% with admin_field|changeform_condition as field %}{{ field.field }}{% endwith %}"
+    ).render(
+        RequestContext(
+            rf.get("/"),
+            {
+                "admin_field": admin_field,
+            },
+        )
+    )
+
+    # ArrayWidget is a MultiWidget whose subwidgets all share the field name, so
+    # a scalar x-model.fill binding would be copied onto every item input and
+    # collapse the array to its first value. changeform_condition must skip it.
+    assert "x-model.fill" not in response
+
+    # Each item keeps its own distinct value (not collapsed to the first).
+    assert 'value="Thomas"' in response
+    assert 'value="Fari"' in response
+    assert 'value="Richard"' in response
+
+
+def _render_changeform_condition(rf, widget, field_name):
+    form_class = type(
+        "ConditionForm",
+        (forms.Form,),
+        {field_name: forms.Field(widget=widget, required=False)},
+    )
+    admin_field = AdminField(form_class(), field_name, False)
+
+    return Template(
+        "{% load unfold %} {% with admin_field|changeform_condition as field %}{{ field.field }}{% endwith %}"
+    ).render(
+        RequestContext(
+            rf.get("/"),
+            {
+                "admin_field": admin_field,
+            },
+        )
+    )
+
+
+def test_tags_changeform_condition_field_integer_range(rf):
+    # Fixed-subwidget MultiWidget that opts into per-item binding: each input
+    # must bind to its own distinct scope variable, never a shared scalar.
+    response = _render_changeform_condition(
+        rf, UnfoldAdminIntegerRangeWidget(), "score"
+    )
+
+    assert 'x-model.fill="score_0"' in response
+    assert 'x-model.fill="score_1"' in response
+
+
+def test_tags_changeform_condition_field_split_datetime_vertical(rf):
+    response = _render_changeform_condition(
+        rf, UnfoldAdminSplitDateTimeVerticalWidget(), "when"
+    )
+
+    assert 'x-model.fill="when_0"' in response
+    assert 'x-model.fill="when_1"' in response
+
+
+def test_tags_changeform_condition_field_custom_multiwidget_skipped(rf):
+    # A MultiWidget that does NOT declare supports_conditional_per_item must be
+    # skipped (safe default): a shared scalar would collapse its subwidgets.
+    class CustomMultiWidget(forms.MultiWidget):
+        def __init__(self, attrs=None):
+            super().__init__([forms.TextInput(), forms.TextInput()], attrs)
+
+        def decompress(self, value):
+            return [None, None]
+
+    response = _render_changeform_condition(rf, CustomMultiWidget(), "custom")
+
+    assert "x-model.fill" not in response
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Fixes #2117. When a `ModelAdmin` used `conditional_fields`, any field rendered with a `MultiWidget` had a single scalar `x-model.fill` binding injected, which Django copies onto every subwidget — Alpine then collapsed all inputs to one value (data loss). This affected `ArrayWidget` (reported), and also `UnfoldAdminIntegerRangeWidget` and `UnfoldAdminSplitDateTimeVerticalWidget`, which fell through to the same generic branch.

`changeform_condition` (and `changeform_data`) now handle `MultiWidget` via an opt-in capability flag:

- Widgets with fixed, distinctly-named subwidgets declare `supports_conditional_per_item = True` and get per-item bindings (`name_0`, `name_1`). Applied to `SplitDateTime`, `SplitDateTimeVertical`, `Money`, `IntegerRange`.
- Any other `MultiWidget` (no flag) is skipped — the safe default. This covers `ArrayWidget` and third-party widgets.

A skipped field can't be a condition *source*, but still works as a *target* (shown/hidden via `x-show`), which is independent. Docs updated accordingly.

## Test plan

- New tag-level tests (form layer, no DB): `ArrayWidget` is not bound and keeps distinct values; `IntegerRange`/`SplitDateTimeVertical` bind per-item; a custom unflagged `MultiWidget` is skipped; `changeform_data` omits unflagged multi-widgets.
- Existing SplitDateTime/Money/Select2/FK/scalar tests still pass.
- `uv run pytest`: 429 passed, coverage 95.70%. `ruff check`/`format` clean.

## Use of AI

AI assisted the root-cause analysis and drafting; all code and tests were reviewed and verified by hand, and the test suite passes.