### PR TITLE
feat: support variant in action row

### DIFF
--- a/docs/actions/changelist-row.md
+++ b/docs/actions/changelist-row.md
@@ -42,3 +42,35 @@ class UserAdmin(ModelAdmin):
         # Write your own bussiness logic. Code below will always display an action.
         return True
 ```
+
+Row actions can also be displayed directly in the changelist row instead of inside
+the dropdown menu by setting `extra_options={"display_in_dropdown": False}`.
+Inline row actions support the same `variant` values as other action buttons.
+
+```python
+# admin.py
+
+from django.contrib.admin import register
+from django.contrib.auth.models import User
+from django.shortcuts import redirect
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.http import HttpRequest
+
+from unfold.admin import ModelAdmin
+from unfold.decorators import action
+from unfold.enums import ActionVariant
+
+
+@register(User)
+class UserAdmin(ModelAdmin):
+    actions_row = ["changelist_row_action"]
+
+    @action(
+        description=_("Changelist row action"),
+        variant=ActionVariant.DANGER,
+        extra_options={"display_in_dropdown": False},
+    )
+    def changelist_row_action(self, request: HttpRequest, object_id: int):
+        return redirect(reverse_lazy("admin:users_user_changelist"))
+```

--- a/src/unfold/mixins/action_model_admin.py
+++ b/src/unfold/mixins/action_model_admin.py
@@ -42,6 +42,7 @@ class ActionModelAdminMixin(ModelAdmin):
                 {
                     "title": action.description,
                     "icon": action.icon,
+                    "variant": action.variant,
                     "attrs": action_attrs,
                     "dialog": action.dialog,
                     "display_in_dropdown": extra_options.get(

--- a/src/unfold/templates/unfold/helpers/actions_row.html
+++ b/src/unfold/templates/unfold/helpers/actions_row.html
@@ -7,7 +7,7 @@
                 {% for action in actions %}
                     {% if not action.display_in_dropdown %}
                         {% url action.raw_path instance_pk as action_url %}
-                    {% component "unfold/components/button.html" with href=action_url size="xs" variant=action.variant.value icon=action.icon class="self-center lg:-my-2"%}
+                        {% component "unfold/components/button.html" with href=action_url size="xs" variant=action.variant.value icon=action.icon class="self-center lg:-my-2"%}
                             {{ action.title }}
                         {% endcomponent %}
                     {% endif %}

--- a/src/unfold/templates/unfold/helpers/actions_row.html
+++ b/src/unfold/templates/unfold/helpers/actions_row.html
@@ -7,7 +7,7 @@
                 {% for action in actions %}
                     {% if not action.display_in_dropdown %}
                         {% url action.raw_path instance_pk as action_url %}
-                        {% component "unfold/components/button.html" with href=action_url size="xs" variant="default" icon=action.icon class="self-center lg:-my-2"%}
+                    {% component "unfold/components/button.html" with href=action_url size="xs" variant=action.variant.value icon=action.icon class="self-center lg:-my-2"%}
                             {{ action.title }}
                         {% endcomponent %}
                     {% endif %}

--- a/tests/server/example/admin.py
+++ b/tests/server/example/admin.py
@@ -69,6 +69,7 @@ from unfold.contrib.import_export.forms import (
 from unfold.contrib.inlines.admin import NonrelatedTabularInline
 from unfold.datasets import BaseDataset
 from unfold.decorators import action, display
+from unfold.enums import ActionVariant
 from unfold.forms import (
     AdminPasswordChangeForm,
     BaseDialogForm,
@@ -691,6 +692,7 @@ class ActionsUserAdmin(BaseUserAdmin, ModelAdmin):
     ]
     actions_row = [
         "changelist_row_action",
+        "changelist_row_action_danger_inline",
         "changelist_row_action_mixed_permissions_true",
         "changelist_row_action_mixed_permissions_false",
         "changelist_row_action_mixed_permissions_perm_not_granted",
@@ -815,6 +817,17 @@ class ActionsUserAdmin(BaseUserAdmin, ModelAdmin):
     @action(description="Changelist row action")
     def changelist_row_action(self, request, object_id):
         messages.success(request, "Changelist row action successfully executed")
+        return redirect(reverse_lazy("admin:example_user_changelist"))
+
+    @action(
+        description="Changelist row action danger inline",
+        variant=ActionVariant.DANGER,
+        extra_options={"display_in_dropdown": False},
+    )
+    def changelist_row_action_danger_inline(self, request, object_id):
+        messages.success(
+            request, "Changelist row action danger inline successfully executed"
+        )
         return redirect(reverse_lazy("admin:example_user_changelist"))
 
     @action(

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -263,6 +263,17 @@ def test_actions_row(client, admin_user):
 
 
 @pytest.mark.django_db
+def test_actions_row_inline_variant(client, admin_user):
+    client.force_login(admin_user)
+    response = client.get(reverse_lazy("admin:example_actionuser_changelist"))
+    content = response.content.decode()
+
+    assert response.status_code == HTTPStatus.OK
+    assert "Changelist row action danger inline" in content
+    assert "bg-red-600" in content
+
+
+@pytest.mark.django_db
 def test_actions_row_mixed_permissions_true(client, staff_user):
     client.force_login(staff_user)
     response = client.get(reverse_lazy("admin:example_actionuser_changelist"))


### PR DESCRIPTION
## Summary

  - Added support for action variants on inline changelist row actions.
  > Previously, row actions rendered outside of the dropdown via `extra_options={"display_in_dropdown": False}` always used the default button variant. Inline row actions now pass the configured `ActionVariant` to the button component, so variants such as `DANGER`, `PRIMARY`, or `SUCCESS` are rendered correctly.
  
- Updated the changelist row actions documentation with an inline row action example using `variant=ActionVariant.DANGER`.

## Test plan

  - Added a test covering an inline changelist row action with `ActionVariant.DANGER`.
  - Verified the rendered changelist contains the row action label.
  - Verified the rendered output contains the expected danger button styling.
  
## Use of AI

AI was used for all changes done.