### PR TITLE
Have submit line delete button use link with preserved filters (#1897)

### DIFF
--- a/src/unfold/templates/admin/submit_line.html
+++ b/src/unfold/templates/admin/submit_line.html
@@ -58,7 +58,7 @@
                         {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
                         {% add_preserved_filters delete_url as link %}
 
-                        {% component "unfold/components/button.html" with href=delete_url variant="danger" class="mr-auto w-full lg:w-auto" %}
+                        {% component "unfold/components/button.html" with href=link variant="danger" class="mr-auto w-full lg:w-auto" %}
                             {% trans "Delete" %} {{ opts.verbose_name }}
                         {% endcomponent %}
                     {% endif %}


### PR DESCRIPTION
Fixes issues #1897.

<!--
Before creating a pull request, make sure all questions below are properly answered.
-->

## Summary

<!-- Describe the changes in detail. Provide screenshots or videos if possible. -->

Carries over preserved filters through the delete button.  The link was already being generated there in the template just not used, as the referenced issue mentioned.

## Test plan

<!-- Describe how exactly you tested the changes. -->

Used the included test server.  Added a new user for test purposes, filtered the list of users by that username just as an example.  Went to the detail model edit page for that user and saw that the filter was now preserved.  Deleted the user and when take back to the list page saw that the filter was still in effect which didn't happen before this PR.

## Use of AI

<!-- Did you use AI to write this pull request? If yes, please provide information which parts of the code were written by AI. -->

`None`
