### PR TITLE
feat: added changeform_fullwidth option to ModelAdmin

### DIFF
--- a/docs/configuration/modeladmin.md
+++ b/docs/configuration/modeladmin.md
@@ -50,6 +50,9 @@ class CustomAdminClass(ModelAdmin):
     # Display changelist in fullwidth
     list_fullwidth = False
 
+    # Display changeform in fullwidth
+    changeform_fullwidth = False
+
     # Set to False, to enable filter as "sidebar"
     list_filter_sheet = True
 

--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -66,6 +66,7 @@ class ModelAdmin(
     list_filter_sheet = True
     list_filter_options: dict[str, ListFilterOptionsItem] = {}
     list_fullwidth = False
+    changeform_fullwidth = False
     list_disable_select_all = False
     list_before_template = None
     list_after_template = None

--- a/src/unfold/templates/admin/base.html
+++ b/src/unfold/templates/admin/base.html
@@ -17,14 +17,14 @@
 
             {% block messages %}
                 <div class="px-4">
-                    <div class="{% if not cl.model_admin.list_fullwidth and is_fullwidth != "1" %}container{% endif %} mx-auto {% element_classes 'messages' %}">
+                    <div class="{% if not cl.model_admin.list_fullwidth and not adminform.model_admin.changeform_fullwidth and is_fullwidth != "1" %}container{% endif %} mx-auto {% element_classes 'messages' %}">
                         {% include "unfold/helpers/messages.html" %}
                     </div>
                 </div>
             {% endblock messages %}
 
             <div class="@container px-4 pb-4 grow">
-                <div id="content" class="{% if not cl.model_admin.list_fullwidth and is_fullwidth != "1" %}container{% endif %} mx-auto {% block coltype %}colM{% endblock %} {% element_classes 'content' %}">
+                <div id="content" class="{% if not cl.model_admin.list_fullwidth and not adminform.model_admin.changeform_fullwidth and is_fullwidth != "1" %}container{% endif %} mx-auto {% block coltype %}colM{% endblock %} {% element_classes 'content' %}">
                     {% if cl %}
                         {% tab_list "changelist" cl.opts %}
                     {% elif opts %}

--- a/src/unfold/templates/unfold/helpers/header.html
+++ b/src/unfold/templates/unfold/helpers/header.html
@@ -1,7 +1,7 @@
 {% load unfold %}
 
 <div class="bg-white border-b border-base-200 mb-4 px-4 z-40 dark:bg-base-900 dark:border-base-800 dark:text-font-default-dark {% element_classes 'header' %}">
-    <div class="{% if not cl.model_admin.list_fullwidth and is_fullwidth != "1" %}container{% endif %} flex items-center h-16 mx-auto py-4 {% element_classes 'header_inner' %}">
+    <div class="{% if not cl.model_admin.list_fullwidth and not adminform.model_admin.changeform_fullwidth and is_fullwidth != "1" %}container{% endif %} flex items-center h-16 mx-auto py-4 {% element_classes 'header_inner' %}">
         <div id="header-inner" class="flex items-center relative w-full">
             <div class="flex items-center w-full">
                 {% block usertools %}


### PR DESCRIPTION
<!--
Before creating a pull request, make sure all questions below are properly answered.
-->

## Summary

Add new option on `src.unfold.admin.ModelAdmin` called `changeform_fullwidth`. When set to `True`, the changeform page for the corresponding `ModelAdmin` has the `container` class remove, allowing the page to be full width.

## Test plan

Visually tested, by trying all permutations of True/False for both `list_fullwidth` and `changeform_fullwidth` to verify they do not interfere with each other.

## Use of AI

Yes, AI was used to help determine a method by which we could have `list_fullwidth` and `changeform_fullwidth` not accidentally interfere with each other in the logic of the `if` statement. 

## Improvements

This implementation depends on the fact that `cl` is only available on the change list view and `adminform` is only available on the change form page. Not my favorite idea, personally... but it works, so I'm just going to create this draft pull request for the moment and I can iterate on the idea later; especially if someone has suggestions!