### PR TITLE
Pass `check_test` callback to super for switch widget

### DIFF
--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -810,8 +810,6 @@ class UnfoldBooleanWidget(CheckboxInput):
     def __init__(
         self, attrs: dict[str, Any] | None = None, check_test: Callable | None = None
     ) -> None:
-        attrs = attrs or {}
-
         super().__init__(
             {
                 **(attrs or {}),

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -832,7 +832,7 @@ class UnfoldBooleanSwitchWidget(CheckboxInput):
                     [*SWITCH_CLASSES, attrs.get("class", "") if attrs else ""]
                 ),
             },
-            check_test=None,
+            check_test,
         )
 
 


### PR DESCRIPTION
Hi,

I noticed that Unfold's switch widget ignores any `check_test` callback. Is there a specific reason for this? `UnfoldBooleanWidget`, on the other hand, passes it to Django's parent, so I just did the same for `UnfoldBooleanSwitchWidget`. Let me know if that's not intended.

## Summary

* Unfold's `UnfoldBooleanSwitchWidget` sub-classes Django's `CheckboxInput`, but throws away any `check_test` callback by always calling super with `None`
* This makes it necessary to set the initial state of this widget using other mechanisms (e.g. `initials`, etc.)
* I simply mirrored what `UnfoldBooleanWidget` does: Pass the `check_test` to super

## Test plan

* Instantiated `UnfoldBooleanSwitchWidget` witch `check_test=...` callbacks.

## Use of AI

None.
