### PR TITLE
fix: Create and assign MultiWidget backing fields for `x-model.fill`

### DIFF
--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -16,7 +16,7 @@ from django.contrib.auth.models import AbstractUser
 from django.core.paginator import Paginator
 from django.db.models import Model
 from django.db.models.options import Options
-from django.forms import BoundField, CheckboxSelectMultiple
+from django.forms import BoundField, CheckboxSelectMultiple, MultiWidget
 from django.http import HttpRequest, QueryDict
 from django.template import Context, Library, Node, RequestContext, TemplateSyntaxError
 from django.template.base import NodeList, Parser, Token, token_kwargs
@@ -547,7 +547,9 @@ def changeform_data(adminform: AdminForm) -> str:
 
                 if isinstance(
                     field.field.field.widget, UnfoldAdminSplitDateTimeWidget
-                ) or isinstance(field.field.field.widget, UnfoldAdminMoneyWidget):
+                ) or isinstance(
+                     field.field.field.widget, UnfoldAdminMoneyWidget
+                ) or isinstance(field.field.field.widget, MultiWidget):
                     for index, _widget in enumerate(field.field.field.widget.widgets):
                         fields[
                             f"{field.field.name}{field.field.field.widget.widgets_names[index]}"
@@ -577,7 +579,9 @@ def changeform_condition(field: AdminField) -> AdminField:
         )
     elif isinstance(
         field.field.field.widget, UnfoldAdminSplitDateTimeWidget
-    ) or isinstance(field.field.field.widget, UnfoldAdminMoneyWidget):
+    ) or isinstance(
+        field.field.field.widget, UnfoldAdminMoneyWidget
+    ) or isinstance(field.field.field.widget, MultiWidget):
         for index, widget in enumerate(field.field.field.widget.widgets):
             field_name = (
                 f"{field.field.name}{field.field.field.widget.widgets_names[index]}"

--- a/src/unfold/templatetags/unfold.py
+++ b/src/unfold/templatetags/unfold.py
@@ -545,11 +545,11 @@ def changeform_data(adminform: AdminForm) -> str:
                 if isinstance(field.field, dict):
                     continue
 
-                if isinstance(
-                    field.field.field.widget, UnfoldAdminSplitDateTimeWidget
-                ) or isinstance(
-                     field.field.field.widget, UnfoldAdminMoneyWidget
-                ) or isinstance(field.field.field.widget, MultiWidget):
+                if (
+                    isinstance(field.field.field.widget, UnfoldAdminSplitDateTimeWidget)
+                    or isinstance(field.field.field.widget, UnfoldAdminMoneyWidget)
+                    or isinstance(field.field.field.widget, MultiWidget)
+                ):
                     for index, _widget in enumerate(field.field.field.widget.widgets):
                         fields[
                             f"{field.field.name}{field.field.field.widget.widgets_names[index]}"
@@ -577,11 +577,11 @@ def changeform_condition(field: AdminField) -> AdminField:
         field.field.field.widget.attrs["x-init"] = mark_safe(
             f"const $ = django.jQuery; $(function () {{ const select = $('#{field.field.auto_id}'); select.on('change', (ev) => {{ {field.field.name} = select.val(); }}); }});"
         )
-    elif isinstance(
-        field.field.field.widget, UnfoldAdminSplitDateTimeWidget
-    ) or isinstance(
-        field.field.field.widget, UnfoldAdminMoneyWidget
-    ) or isinstance(field.field.field.widget, MultiWidget):
+    elif (
+        isinstance(field.field.field.widget, UnfoldAdminSplitDateTimeWidget)
+        or isinstance(field.field.field.widget, UnfoldAdminMoneyWidget)
+        or isinstance(field.field.field.widget, MultiWidget)
+    ):
         for index, widget in enumerate(field.field.field.widget.widgets):
             field_name = (
                 f"{field.field.name}{field.field.field.widget.widgets_names[index]}"


### PR DESCRIPTION
Hi again!

I noticed another issue when working with Django's `MultiWidget`.

TLDR: Alpine's `x-model.fill` attributes need to know each child field of a `MultiWidget` (when working with `conditional_fields`). Otherwise, this happens:

https://github.com/user-attachments/assets/b9d72feb-754d-4372-8625-05c0fc86db0c

Or with `<select>` widgets:

https://github.com/user-attachments/assets/64bbe1a4-f72b-4a70-985b-ac4c6090be81

***

## Summary

This issue needs some setup. Consider an AdminForm that uses a MultiWidget:

```python
class NameWidget(forms.MultiWidget):
    def __init__(self, attrs=None):
        widgets = [
            UnfoldAdminTextInputWidget(),
            UnfoldAdminTextInputWidget()
        ]
        super().__init__(widgets, attrs)

    def decompress(self, value):
        if value:
            return value.split(" ", 1)
        return ["", ""]

    def value_from_datadict(self, data, files, name):
        values = super().value_from_datadict(data, files, name)
        return f"{values[0]} {values[1]}".strip()

class MyNameForm(forms.ModelForm):
    class Meta:
        model = MyName
        fields = ("myname",)

    myname = forms.CharField(widget=NameWidget)
```

And then I need to trigger Unfold's `conditional_fields` logic, so I just add something to it:

```python
@admin.register(MyName)
class MyNameAdmin(ModelAdmin):
    form = MyNameForm
    conditional_fields = {
        "true": "true"
    }
```

This will cause the the widget template to add Alpine.js attributes to its HTML: `<input type="text" name="myname_0" class="..." x-model.fill="myname" required="" id="id_myname_0">`

However, these attributes are applied to **both** text inputs. The issue here is that this uses `myname` (the "mother form attribute") to fill its value, so both text inputs are connected to the same "source."

The fix is to make Alpine.js aware of Django's "child fields." This is actually already happening for some Unfold widgets (e.g. `UnfoldAdminSplitDateTimeWidget`), it should just be applied to every `MultiWidget`. I extended `src/unfold/templatetags/unfold.py` with that.

## Test plan

As far as I'm aware, there is no setup to test client-side Alpine.js logic. I was only able to confirm these changes locally. However, the logic is basically the same to what already happens with Unfold's other "combined widgets."

## Use of AI

None. I checked the logic in `templatetags/unfold.py` and saw the issue.