### PR TITLE
fix: restore changelist action state after navigation

### DIFF
--- a/src/unfold/forms.py
+++ b/src/unfold/forms.py
@@ -72,7 +72,9 @@ class ActionForm(forms.Form):
                     ]
                 ),
                 "aria-label": _("Select action to run"),
+                "x-init": "action = $el.value",
                 "x-model": "action",
+                "x-on:pageshow.window": "action = $el.value",
             }
         ),
     )

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -81,6 +81,16 @@ def test_actions_list(client, admin_user):
 
 
 @pytest.mark.django_db
+def test_actions_list_restores_selected_action(admin_client):
+    response = admin_client.get(reverse_lazy("admin:example_actionuser_changelist"))
+    content = response.content.decode()
+
+    assert 'x-init="action = $el.value"' in content
+    assert 'x-on:pageshow.window="action = $el.value"' in content
+    assert '<button type="submit" x-show="action"' in content
+
+
+@pytest.mark.django_db
 def test_actions_list_with_dropdown(client, admin_user):
     client.force_login(admin_user)
     response = client.get(reverse_lazy("admin:example_actionuser_changelist"))


### PR DESCRIPTION
## Summary

After running a changelist action with a confirmation page, such as Delete selected, navigating back restores   
 the native action select value but not Unfold’s Alpine action state. Consequently, x-show="action" remains    
 false and the Run button disappears.                                                                            
                                                                                                                 
 This change synchronizes Alpine state with the select value during initialization and on pageshow, covering     
 browser back/BFCache restoration.                                                                               
                                                                                                                 
 A regression test verifies the required Alpine bindings. No existing issue or PR covering this exact navigation 
 case was found.

## Test plan

+ regression test
+ UI test manually

https://github.com/user-attachments/assets/3684b085-d4cb-49e5-be82-403d2841833c

https://github.com/user-attachments/assets/f2510cac-ef0a-4b9a-9d5b-9d0546360390





## Use of AI

All changes have been done by AI
