### PR TITLE
feat: add dependent autocomplete fields

### DIFF
--- a/docs/configuration/autocomplete-dependencies.md
+++ b/docs/configuration/autocomplete-dependencies.md
@@ -1,0 +1,108 @@
+---
+title: Autocomplete dependencies
+order: 3
+description: Limit Django admin autocomplete choices based on another field, such as Country → State → City.
+---
+
+# Autocomplete dependencies
+
+`autocomplete_dependencies` extends Django Admin's native `autocomplete_fields`. When a parent field changes, child autocomplete results are limited to related objects. Use it for chains such as Country → State → City.
+
+Requirements:
+
+- Child fields must also be listed in `autocomplete_fields`.
+- Child and parent fields must be `ForeignKey`s.
+- The related model's `ModelAdmin` must define `search_fields`, as required by Django autocomplete.
+- `lookup` must be a direct ForeignKey field name on the autocomplete target model. Relation traversal with `__` is not supported.
+
+The same mapping works on `ModelAdmin` and Unfold inlines. Dependencies resolve on the same form, or on the same inline row.
+
+Changing a parent clears dependent descendants. Existing saved values stay visible until the parent changes.
+
+## Shorthand syntax
+
+When the parent form field name matches the ForeignKey on the related model, map the child field to that name:
+
+```python
+# admin.py
+
+from django.contrib import admin
+from unfold.admin import ModelAdmin
+
+from .models import City, Country, Location, State
+
+
+@admin.register(Country)
+class CountryAdmin(ModelAdmin):
+    search_fields = ["name"]
+
+
+@admin.register(State)
+class StateAdmin(ModelAdmin):
+    search_fields = ["name"]
+
+
+@admin.register(City)
+class CityAdmin(ModelAdmin):
+    search_fields = ["name"]
+
+
+@admin.register(Location)
+class LocationAdmin(ModelAdmin):
+    autocomplete_fields = ["state", "city"]
+    autocomplete_dependencies = {
+        "state": "country",
+        "city": "state",
+    }
+```
+
+Here `"state": "country"` means the `state` autocomplete depends on the `country` form field, and `State.country` is the lookup used to filter results.
+
+## Explicit syntax
+
+When the form field name differs from the ForeignKey on the target model, set `depends_on` and `lookup` separately:
+
+- `depends_on` is the field on the current admin form.
+- `lookup` is the ForeignKey on the autocomplete target model.
+
+```python
+# admin.py
+
+from django.contrib import admin
+from unfold.admin import ModelAdmin, TabularInline
+
+from .models import Address, PersonLocation
+
+
+@admin.register(Address)
+class AddressAdmin(ModelAdmin):
+    autocomplete_fields = ["selected_state", "selected_city"]
+    autocomplete_dependencies = {
+        "selected_state": {
+            "depends_on": "selected_country",
+            "lookup": "country",
+        },
+        "selected_city": {
+            "depends_on": "selected_state",
+            "lookup": "state",
+        },
+    }
+
+
+class PersonLocationInline(TabularInline):
+    model = PersonLocation
+    extra = 1
+    autocomplete_fields = ["selected_state", "selected_city"]
+    autocomplete_dependencies = {
+        "selected_state": {
+            "depends_on": "selected_country",
+            "lookup": "country",
+        },
+        "selected_city": {
+            "depends_on": "selected_state",
+            "lookup": "state",
+        },
+    }
+```
+
+`selected_city` depends on the `selected_state` form field. Results are filtered with `City.state`, not a field named `selected_state`.

--- a/docs/configuration/modeladmin.md
+++ b/docs/configuration/modeladmin.md
@@ -27,6 +27,13 @@ class CustomAdminClass(ModelAdmin):
     # Warn before leaving unsaved changes in changeform
     warn_unsaved_form = True  # Default: False
 
+    # Limit autocomplete options based on another ForeignKey
+    autocomplete_fields = ["state", "city"]
+    autocomplete_dependencies = {
+        "state": "country",
+        "city": "state",
+    }
+
     # Preprocess content of readonly fields before render
     readonly_preprocess_fields = {
         "model_field_name": "html.unescape",

--- a/src/unfold/admin.py
+++ b/src/unfold/admin.py
@@ -21,7 +21,7 @@ from django.utils.safestring import SafeString, mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 
-from unfold.checks import UnfoldModelAdminChecks
+from unfold.checks import UnfoldInlineModelAdminChecks, UnfoldModelAdminChecks
 from unfold.forms import (
     ActionForm,
     PaginationGenericInlineFormSet,
@@ -34,7 +34,7 @@ from unfold.mixins import (
     NestedInlinesModelAdminMixin,
 )
 from unfold.overrides import FORMFIELD_OVERRIDES_INLINE
-from unfold.views import ChangeList
+from unfold.views import ChangeList, DependentAutocompleteJsonView
 from unfold.widgets import UnfoldBooleanWidget
 
 checkbox = UnfoldBooleanWidget(
@@ -201,13 +201,62 @@ class ModelAdmin(
             for action in self._get_base_actions_row()
         ]
 
+        dependent_autocomplete_urls = []
+        seen_url_names: set[str] = set()
+        for source_admin in self._dependent_autocomplete_source_admins():
+            url_name = source_admin.get_dependent_autocomplete_url_name()
+            if url_name in seen_url_names:
+                continue
+            seen_url_names.add(url_name)
+            dependent_autocomplete_urls.append(
+                path(
+                    self._dependent_autocomplete_path(source_admin),
+                    wrap(self._bound_dependent_autocomplete_view(source_admin)),
+                    name=url_name,
+                )
+            )
+
         return (
-            custom_urls
+            dependent_autocomplete_urls
+            + custom_urls
             + action_row_urls
             + actions_list_urls
             + action_detail_urls
             + urls
         )
+
+    def _dependent_autocomplete_source_admins(self) -> list[InlineModelAdmin | Any]:
+        sources: list[InlineModelAdmin | Any] = []
+        if self.autocomplete_dependencies:
+            sources.append(self)
+        for inline_class in self.inlines:
+            inline = inline_class(self.model, self.admin_site)
+            if getattr(inline, "autocomplete_dependencies", None):
+                sources.append(inline)
+        return sources
+
+    def _dependent_autocomplete_path(self, source_admin: InlineModelAdmin | Any) -> str:
+        if source_admin is self:
+            return "dependent-autocomplete/"
+        return f"inline/{source_admin.__class__.__name__}/dependent-autocomplete/"
+
+    def _bound_dependent_autocomplete_view(self, source_admin: InlineModelAdmin | Any):
+        def view(request: HttpRequest) -> HttpResponse:
+            return self.dependent_autocomplete_view(request, source_admin=source_admin)
+
+        view.__name__ = "dependent_autocomplete_view"
+        view.__qualname__ = "dependent_autocomplete_view"
+        return view
+
+    def dependent_autocomplete_view(
+        self,
+        request: HttpRequest,
+        source_admin: InlineModelAdmin | Any | None = None,
+    ) -> HttpResponse:
+        return DependentAutocompleteJsonView.as_view(
+            admin_site=self.admin_site,
+            source_model_admin=source_admin or self,
+        )(request)
 
     def _path_from_custom_url(self, custom_url: tuple[str, str, View]) -> URLPattern:
         return path(
@@ -279,19 +328,23 @@ class BaseInlineMixin:
 
 class TabularInline(BaseInlineMixin, FormFieldModelAdminMixin, BaseTabularInline):
     formset = PaginationInlineFormSet
+    checks_class = UnfoldInlineModelAdminChecks
 
 
 class StackedInline(BaseInlineMixin, FormFieldModelAdminMixin, BaseStackedInline):
     formset = PaginationInlineFormSet
+    checks_class = UnfoldInlineModelAdminChecks
 
 
 class GenericStackedInline(
     BaseInlineMixin, FormFieldModelAdminMixin, BaseGenericStackedInline
 ):
     formset = PaginationGenericInlineFormSet
+    checks_class = UnfoldInlineModelAdminChecks
 
 
 class GenericTabularInline(
     BaseInlineMixin, FormFieldModelAdminMixin, BaseGenericTabularInline
 ):
     formset = PaginationGenericInlineFormSet
+    checks_class = UnfoldInlineModelAdminChecks

--- a/src/unfold/checks.py
+++ b/src/unfold/checks.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.contrib.admin.checks import ModelAdminChecks
+from django.contrib.admin.checks import InlineModelAdminChecks, ModelAdminChecks
 from django.contrib.admin.options import BaseModelAdmin
 from django.contrib.auth.models import Permission
 from django.core import checks
@@ -14,7 +14,42 @@ class UnfoldModelAdminChecks(ModelAdminChecks):
         return [
             *super().check(admin_obj, **kwargs),
             *self._check_unfold_action_permission_methods(admin_obj),
+            *self._check_autocomplete_dependencies(admin_obj),
+            *self._check_duplicate_dependent_autocomplete_urls(admin_obj),
         ]
+
+    def _check_autocomplete_dependencies(self, obj: Any) -> list[checks.Error]:
+        if hasattr(obj, "_check_autocomplete_dependencies"):
+            return obj._check_autocomplete_dependencies()
+        return []
+
+    def _check_duplicate_dependent_autocomplete_urls(
+        self, obj: Any
+    ) -> list[checks.Error]:
+        names: list[str] = []
+        inlines = getattr(obj, "inlines", ())
+        if not isinstance(inlines, list | tuple):
+            return []
+        for inline_class in inlines:
+            inline = inline_class(obj.model, obj.admin_site)
+            if getattr(inline, "autocomplete_dependencies", None):
+                names.append(inline.get_dependent_autocomplete_url_name())
+
+        seen: set[str] = set()
+        errors = []
+        for name in names:
+            if name in seen:
+                errors.append(
+                    checks.Error(
+                        "Multiple inlines generate the same dependent autocomplete URL "
+                        f"name '{name}'. Rename an inline class so each config owner "
+                        "has a unique URL.",
+                        obj=obj,
+                        id="unfold.E009",
+                    )
+                )
+            seen.add(name)
+        return errors
 
     def _check_unfold_action_permission_methods(self, obj: Any) -> list[checks.Error]:
         """
@@ -63,3 +98,16 @@ class UnfoldModelAdminChecks(ModelAdminChecks):
                     )
 
         return errors
+
+
+class UnfoldInlineModelAdminChecks(InlineModelAdminChecks):
+    def check(self, inline_obj: BaseModelAdmin, **kwargs) -> list[CheckMessage]:
+        return [
+            *super().check(inline_obj, **kwargs),
+            *self._check_autocomplete_dependencies(inline_obj),
+        ]
+
+    def _check_autocomplete_dependencies(self, obj: Any) -> list[checks.Error]:
+        if hasattr(obj, "_check_autocomplete_dependencies"):
+            return obj._check_autocomplete_dependencies()
+        return []

--- a/src/unfold/mixins/formfield_model_admin.py
+++ b/src/unfold/mixins/formfield_model_admin.py
@@ -1,14 +1,17 @@
 import copy
+from collections.abc import Mapping
 from typing import Any
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.admin.options import BaseModelAdmin
+from django.contrib.admin.options import BaseModelAdmin, InlineModelAdmin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.admin.widgets import (
     FilteredSelectMultiple,
     RelatedFieldWidgetWrapper,
 )
+from django.core import checks
+from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignKey, ManyToManyField
@@ -29,6 +32,7 @@ class FormFieldModelAdminMixin(BaseModelAdmin):
     # List of all db fields which are not available in autocomplete_fields
     _autocomplete_fields_missing: list[str] = []
     autocomplete_fields_excluded_from_warnings: list[str] = []
+    autocomplete_dependencies: dict[str, str | dict[str, str]] = {}
 
     def __init__(self, model: type[models.Model], admin_site: AdminSite) -> None:
         overrides = copy.deepcopy(FORMFIELD_OVERRIDES)
@@ -58,6 +62,35 @@ class FormFieldModelAdminMixin(BaseModelAdmin):
 
         return super().formfield_for_choice_field(db_field, request, **kwargs)
 
+    def get_autocomplete_dependency_config(
+        self, field_name: str
+    ) -> dict[str, str] | None:
+        dependencies = self.autocomplete_dependencies
+        if not isinstance(dependencies, Mapping):
+            return None
+        dependency = dependencies.get(field_name)
+        if isinstance(dependency, str):
+            return {"depends_on": dependency, "lookup": dependency}
+        if not isinstance(dependency, Mapping):
+            return None
+        depends_on = dependency.get("depends_on")
+        lookup = dependency.get("lookup")
+        if not isinstance(depends_on, str) or not isinstance(lookup, str):
+            return None
+        return {"depends_on": depends_on, "lookup": lookup}
+
+    def get_dependent_autocomplete_url_name(self) -> str:
+        if isinstance(self, InlineModelAdmin):
+            parent = self.parent_model._meta
+            inline_name = self.__class__.__name__.lower()
+            return (
+                f"{parent.app_label}_{parent.model_name}_{inline_name}"
+                "_dependent_autocomplete"
+            )
+
+        opts = self.model._meta
+        return f"{opts.app_label}_{opts.model_name}_dependent_autocomplete"
+
     def formfield_for_foreignkey(
         self, db_field: ForeignKey, request: HttpRequest, **kwargs: Any
     ) -> ModelChoiceField | None:
@@ -67,10 +100,17 @@ class FormFieldModelAdminMixin(BaseModelAdmin):
                 kwargs["widget"] = widgets.UnfoldForeignKeyRawIdWidget(
                     db_field.remote_field, self.admin_site, using=kwargs.get("using")
                 )
-            elif (
-                db_field.name not in self.get_autocomplete_fields(request)
-                and db_field.name not in self.radio_fields
-            ):
+            elif db_field.name in self.get_autocomplete_fields(request):
+                dependency = self.get_autocomplete_dependency_config(db_field.name)
+                if dependency:
+                    kwargs["widget"] = widgets.DependentAutocompleteSelect(
+                        db_field,
+                        self.admin_site,
+                        using=kwargs.get("using"),
+                        parent_field_name=dependency["depends_on"],
+                        source_admin=self,
+                    )
+            elif db_field.name not in self.radio_fields:
                 kwargs["widget"] = widgets.UnfoldAdminSelectWidget()
                 kwargs["empty_label"] = _("Select value")
 
@@ -183,3 +223,119 @@ class FormFieldModelAdminMixin(BaseModelAdmin):
 
         if field_name not in self._autocomplete_fields_missing:
             self._autocomplete_fields_missing.append(field_name)
+
+    def _check_autocomplete_dependencies(self) -> list[checks.Error]:
+        dependencies = self.autocomplete_dependencies
+        if not dependencies:
+            return []
+        if not isinstance(dependencies, Mapping):
+            return [
+                checks.Error(
+                    "autocomplete_dependencies must be a mapping of child field to parent field.",
+                    obj=self,
+                    id="unfold.E001",
+                )
+            ]
+
+        errors = []
+        autocomplete_fields = set(self.autocomplete_fields)
+        for child_name, dependency in dependencies.items():
+            if not isinstance(child_name, str):
+                errors.append(
+                    checks.Error(
+                        "autocomplete_dependencies keys must be field names.",
+                        obj=self,
+                        id="unfold.E002",
+                    )
+                )
+                continue
+            if isinstance(dependency, str):
+                parent_name = dependency
+                lookup = dependency
+            elif isinstance(dependency, Mapping):
+                parent_name = dependency.get("depends_on")
+                lookup = dependency.get("lookup")
+            else:
+                parent_name = lookup = None
+            if not isinstance(parent_name, str) or not isinstance(lookup, str):
+                errors.append(
+                    checks.Error(
+                        "Each dependency must be a parent field name or a mapping with "
+                        "'depends_on' and 'lookup' field names.",
+                        obj=self,
+                        id="unfold.E002",
+                    )
+                )
+                continue
+            if "__" in lookup:
+                errors.append(
+                    checks.Error(
+                        "Dependency lookup must be a single ForeignKey field name, not a relation lookup.",
+                        obj=self,
+                        id="unfold.E008",
+                    )
+                )
+                continue
+            if child_name not in autocomplete_fields:
+                errors.append(
+                    checks.Error(
+                        f"'{child_name}' must also be listed in autocomplete_fields.",
+                        obj=self,
+                        id="unfold.E003",
+                    )
+                )
+                continue
+            errors.extend(
+                self._check_autocomplete_dependency_fields(
+                    child_name, parent_name, lookup
+                )
+            )
+        return errors
+
+    def _check_autocomplete_dependency_fields(
+        self, child_name: str, parent_name: str, lookup: str
+    ) -> list[checks.Error]:
+        try:
+            child_field = self.model._meta.get_field(child_name)
+            parent_field = self.model._meta.get_field(parent_name)
+        except FieldDoesNotExist:
+            return [
+                checks.Error(
+                    f"'{child_name}' and '{parent_name}' must be fields on {self.model._meta.label}.",
+                    obj=self,
+                    id="unfold.E004",
+                )
+            ]
+        if not isinstance(child_field, models.ForeignKey) or not isinstance(
+            parent_field, models.ForeignKey
+        ):
+            return [
+                checks.Error(
+                    "Dependent autocompletes require ForeignKey child and parent fields.",
+                    obj=self,
+                    id="unfold.E005",
+                )
+            ]
+        try:
+            target_parent_field = child_field.remote_field.model._meta.get_field(lookup)
+        except FieldDoesNotExist:
+            return [
+                checks.Error(
+                    f"{child_field.remote_field.model._meta.label} needs a ForeignKey named '{lookup}'.",
+                    obj=self,
+                    id="unfold.E006",
+                )
+            ]
+        if not isinstance(target_parent_field, models.ForeignKey) or (
+            target_parent_field.remote_field.model
+            is not parent_field.remote_field.model
+        ):
+            return [
+                checks.Error(
+                    f"'{lookup}' on {child_field.remote_field.model._meta.label} must point to "
+                    f"{parent_field.remote_field.model._meta.label}.",
+                    obj=self,
+                    id="unfold.E007",
+                )
+            ]
+        return []

--- a/src/unfold/mixins/formfield_model_admin.py
+++ b/src/unfold/mixins/formfield_model_admin.py
@@ -103,7 +103,7 @@ class FormFieldModelAdminMixin(BaseModelAdmin):
             elif db_field.name in self.get_autocomplete_fields(request):
                 dependency = self.get_autocomplete_dependency_config(db_field.name)
                 if dependency:
-                    kwargs["widget"] = widgets.DependentAutocompleteSelect(
+                    kwargs["widget"] = widgets.UnfoldAdminDependentAutocompleteSelect(
                         db_field,
                         self.admin_site,
                         using=kwargs.get("using"),

--- a/src/unfold/static/unfold/js/dependent-autocomplete.js
+++ b/src/unfold/static/unfold/js/dependent-autocomplete.js
@@ -1,0 +1,105 @@
+"use strict";
+{
+	const $ = django.jQuery;
+
+	function fieldNameForParent(child, parentField) {
+		const parts = child.name.split("-");
+		parts[parts.length - 1] = parentField;
+		return parts.join("-");
+	}
+
+	function resolveParent(child) {
+		const parentName = child.dataset.dependentAutocompleteParent;
+		const parentId = "id_" + fieldNameForParent(child, parentName);
+		return document.getElementById(parentId);
+	}
+
+	function parameter(data, name) {
+		if (typeof data !== "string") {
+			return data && Object.prototype.hasOwnProperty.call(data, name)
+				? data[name]
+				: null;
+		}
+		const match = new RegExp("(?:^|&)" + name + "=([^&]*)").exec(data);
+		return match
+			? decodeURIComponent(match[1].replace(/\+/g, " "))
+			: null;
+	}
+
+	function pathFor(url) {
+		const link = document.createElement("a");
+		link.href = url;
+		return link.pathname;
+	}
+
+	function childForRequest(settings, data) {
+		const fieldName = parameter(data, "field_name");
+		const endpoint = pathFor(settings.url);
+		const candidates = $("select[data-dependent-autocomplete-parent]").filter(
+			function () {
+				return (
+					$(this).attr("data-field-name") === fieldName &&
+					pathFor($(this).attr("data-ajax--url")) === endpoint
+				);
+			},
+		);
+		const active = candidates.filter(function () {
+			return $(this)
+				.next(".select2-container")
+				.hasClass("select2-container--open");
+		});
+		return active.first().length ? active.first() : candidates.first();
+	}
+
+	$(function () {
+		$.ajaxPrefilter(function (options) {
+			const $child = childForRequest(options, options.data || {});
+			if (!$child.length) {
+				return;
+			}
+			const element = $child[0];
+			const parentElement = resolveParent(element);
+			const parentValue = parentElement ? parentElement.value : "";
+			if (typeof options.data === "string") {
+				options.data +=
+					(options.data ? "&" : "") +
+					$.param({ dependent_parent: parentValue });
+			} else {
+				options.data = $.extend({}, options.data, {
+					dependent_parent: parentValue,
+				});
+			}
+		});
+
+		function clearDependentChildren(parent, cleared) {
+			cleared = cleared || [];
+			if (cleared.indexOf(parent) !== -1) {
+				return;
+			}
+			cleared.push(parent);
+			$("select[data-dependent-autocomplete-parent]").each(function () {
+				const parentElement = resolveParent(this);
+				if (parentElement === parent) {
+					$(this).val(null).trigger("change");
+					clearDependentChildren(this, cleared);
+				}
+			});
+		}
+
+		$(document).on(
+			"change",
+			"select:not(.admin-autocomplete)",
+			function () {
+				clearDependentChildren(this);
+			},
+		);
+
+		$(document).on(
+			"select2:select select2:clear",
+			"select.admin-autocomplete",
+			function () {
+				clearDependentChildren(this);
+			},
+		);
+	});
+}

--- a/src/unfold/views.py
+++ b/src/unfold/views.py
@@ -3,8 +3,11 @@ from typing import TYPE_CHECKING, Any
 from django.contrib import messages
 from django.contrib.admin import AdminSite
 from django.contrib.admin.filters import ListFilter
+from django.contrib.admin.views.autocomplete import AutocompleteJsonView
 from django.contrib.admin.views.main import ChangeList as BaseChangeList
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.exceptions import FieldDoesNotExist, PermissionDenied, ValidationError
+from django.db import models
 from django.db.models import QuerySet
 from django.http import HttpRequest, JsonResponse
 from django.views import View
@@ -147,3 +150,68 @@ class BaseAutocompleteView(ListView):
                 },
             }
         )
+
+
+DEPENDENT_PARENT_PARAM = "dependent_parent"
+
+
+class DependentAutocompleteJsonView(AutocompleteJsonView):
+    """Apply one configured ForeignKey filter before Django's autocomplete search."""
+
+    source_model_admin = None
+
+    def process_request(self, request: HttpRequest):
+        result = super().process_request(request)
+        if self.source_model_admin is None:
+            raise PermissionDenied
+
+        # The custom URL is owned by one source ModelAdmin. Do not permit a
+        # caller to substitute another source model or autocomplete field.
+        if result[2].model is not self.source_model_admin.model:
+            raise PermissionDenied
+
+        dependency = self.source_model_admin.get_autocomplete_dependency_config(
+            result[2].name
+        )
+        if dependency is None:
+            raise PermissionDenied
+        parent_name = dependency["depends_on"]
+        lookup = dependency["lookup"]
+        if "__" in lookup:
+            raise PermissionDenied
+
+        try:
+            self.source_parent_field = self.source_model_admin.model._meta.get_field(
+                parent_name
+            )
+            self.target_parent_field = result[1].model._meta.get_field(lookup)
+        except FieldDoesNotExist as exc:
+            raise PermissionDenied from exc
+        if (
+            not isinstance(self.source_parent_field, models.ForeignKey)
+            or not isinstance(self.target_parent_field, models.ForeignKey)
+            or self.target_parent_field.remote_field.model
+            is not self.source_parent_field.remote_field.model
+        ):
+            raise PermissionDenied
+        return result
+
+    def get_queryset(self) -> QuerySet:
+        queryset = self.model_admin.get_queryset(self.request)
+        queryset = queryset.complex_filter(self.source_field.get_limit_choices_to())
+
+        parent_value = self.request.GET.get(DEPENDENT_PARENT_PARAM)
+        if not parent_value:
+            return queryset.none()
+        try:
+            parent_value = self.source_parent_field.target_field.to_python(parent_value)
+        except (TypeError, ValueError, ValidationError):
+            return queryset.none()
+
+        queryset = queryset.filter(**{self.target_parent_field.name: parent_value})
+        queryset, search_use_distinct = self.model_admin.get_search_results(
+            self.request, queryset, self.term
+        )
+        if search_use_distinct:
+            queryset = queryset.distinct()
+        return queryset

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -953,7 +953,7 @@ class UnfoldAdminRelatedFieldWrapperWidget(RelatedFieldWidgetWrapper):
     template_name = "unfold/widgets/related_widget_wrapper.html"
 
 
-class DependentAutocompleteSelect(AutocompleteSelect):
+class UnfoldAdminDependentAutocompleteSelect(AutocompleteSelect):
     """Native admin autocomplete widget with one ForeignKey parent dependency."""
 
     def __init__(

--- a/src/unfold/widgets.py
+++ b/src/unfold/widgets.py
@@ -19,6 +19,7 @@ from django.contrib.admin.widgets import (
     AdminTimeWidget,
     AdminURLFieldWidget,
     AdminUUIDInputWidget,
+    AutocompleteSelect,
     ForeignKeyRawIdWidget,
     RelatedFieldWidgetWrapper,
 )
@@ -35,6 +36,7 @@ from django.forms import (
     SelectMultiple,
 )
 from django.forms.widgets import Input
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from unfold.exceptions import UnfoldException
@@ -949,6 +951,60 @@ class UnfoldAdminMultipleAutocompleteModelChoiceFieldWidget(
 
 class UnfoldAdminRelatedFieldWrapperWidget(RelatedFieldWidgetWrapper):
     template_name = "unfold/widgets/related_widget_wrapper.html"
+
+
+class DependentAutocompleteSelect(AutocompleteSelect):
+    """Native admin autocomplete widget with one ForeignKey parent dependency."""
+
+    def __init__(
+        self,
+        *args: Any,
+        parent_field_name: str,
+        source_admin: Any,
+        **kwargs: Any,
+    ) -> None:
+        self.parent_field_name = parent_field_name
+        self.source_admin = source_admin
+        super().__init__(*args, **kwargs)
+
+    def get_url(self) -> str:
+        return reverse(
+            f"{self.admin_site.name}:{self.source_admin.get_dependent_autocomplete_url_name()}"
+        )
+
+    def build_attrs(
+        self, base_attrs: dict[str, Any], extra_attrs: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        attrs = super().build_attrs(base_attrs, extra_attrs=extra_attrs)
+        attrs["data-dependent-autocomplete-parent"] = self.parent_field_name
+        return attrs
+
+    @property
+    def media(self) -> forms.Media:
+        # Mirrors django.contrib.admin.widgets.AutocompleteMixin.media so the
+        # dependent script loads after native autocomplete initialization.
+        extra = "" if settings.DEBUG else ".min"
+        i18n_file = (
+            (f"admin/js/vendor/select2/i18n/{self.i18n_name}.js",)
+            if self.i18n_name
+            else ()
+        )
+        return forms.Media(
+            js=(
+                f"admin/js/vendor/jquery/jquery{extra}.js",
+                f"admin/js/vendor/select2/select2.full{extra}.js",
+                *i18n_file,
+                "admin/js/jquery.init.js",
+                "admin/js/autocomplete.js",
+                "unfold/js/dependent-autocomplete.js",
+            ),
+            css={
+                "screen": (
+                    f"admin/css/vendor/select2/select2{extra}.css",
+                    "admin/css/autocomplete.css",
+                ),
+            },
+        )
 
 
 try:

--- a/tests/server/example/admin.py
+++ b/tests/server/example/admin.py
@@ -19,19 +19,25 @@ from waffle.models import Flag, Sample, Switch
 
 from example.models import (
     ActionUser,
+    Address,
     ApprovalChoices,
     Category,
+    City,
     ColorChoices,
+    Country,
     DialogActionUser,
     FilterUser,
     Invoice,
     InvoiceItem,
     Label,
+    Person,
+    PersonLocation,
     Post,
     PriorityChoices,
     Profile,
     Project,
     SectionUser,
+    State,
     StatusChoices,
     Tag,
     Task,
@@ -1138,3 +1144,62 @@ class TaskAdmin(ModelAdmin):
 @admin.register(Profile)
 class ProfileAdmin(ModelAdmin):
     search_fields = ["name"]
+
+
+@admin.register(Country)
+class CountryAdmin(ModelAdmin):
+    search_fields = ["name"]
+
+
+@admin.register(State)
+class StateAdmin(ModelAdmin):
+    search_fields = ["name"]
+
+
+@admin.register(City)
+class CityAdmin(ModelAdmin):
+    search_fields = ["name"]
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term
+        )
+        if request.GET.get("custom_only"):
+            queryset = queryset.filter(name__startswith="San")
+        return queryset, use_distinct
+
+
+@admin.register(Address)
+class AddressAdmin(ModelAdmin):
+    autocomplete_fields = ["selected_state", "selected_city", "backup_city"]
+    autocomplete_dependencies = {
+        "selected_state": {
+            "depends_on": "selected_country",
+            "lookup": "country",
+        },
+        "selected_city": {
+            "depends_on": "selected_state",
+            "lookup": "state",
+        },
+    }
+
+
+class PersonLocationInline(TabularInline):
+    model = PersonLocation
+    extra = 1
+    autocomplete_fields = ["selected_state", "selected_city"]
+    autocomplete_dependencies = {
+        "selected_state": {
+            "depends_on": "selected_country",
+            "lookup": "country",
+        },
+        "selected_city": {
+            "depends_on": "selected_state",
+            "lookup": "state",
+        },
+    }
+
+
+@admin.register(Person)
+class PersonAdmin(ModelAdmin):
+    inlines = [PersonLocationInline]

--- a/tests/server/example/models.py
+++ b/tests/server/example/models.py
@@ -190,3 +190,67 @@ class Profile(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class Country(models.Model):
+    name = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.name
+
+
+class State(models.Model):
+    country = models.ForeignKey(Country, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ["name"]
+
+
+class City(models.Model):
+    state = models.ForeignKey(State, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ["name"]
+
+
+class Address(models.Model):
+    selected_country = models.ForeignKey(Country, on_delete=models.CASCADE)
+    selected_state = models.ForeignKey(State, on_delete=models.CASCADE)
+    selected_city = models.ForeignKey(City, on_delete=models.CASCADE)
+    backup_city = models.ForeignKey(
+        City,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="backup_addresses",
+    )
+    street = models.CharField(max_length=200)
+
+    def __str__(self):
+        return self.street
+
+
+class Person(models.Model):
+    name = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.name
+
+
+class PersonLocation(models.Model):
+    person = models.ForeignKey(Person, on_delete=models.CASCADE)
+    selected_country = models.ForeignKey(Country, on_delete=models.CASCADE)
+    selected_state = models.ForeignKey(State, on_delete=models.CASCADE)
+    selected_city = models.ForeignKey(City, on_delete=models.CASCADE)
+    street = models.CharField(max_length=200)
+
+    def __str__(self):
+        return self.street

--- a/tests/test_dependent_autocomplete.py
+++ b/tests/test_dependent_autocomplete.py
@@ -13,7 +13,7 @@ from example.models import Address, City, Country, Person, PersonLocation, State
 from unfold.admin import GenericTabularInline, ModelAdmin, TabularInline
 from unfold.sites import UnfoldAdminSite
 from unfold.views import DependentAutocompleteJsonView
-from unfold.widgets import DependentAutocompleteSelect
+from unfold.widgets import UnfoldAdminDependentAutocompleteSelect
 
 
 @pytest.fixture
@@ -66,7 +66,7 @@ def result_texts(response):
 
 def test_dependent_autocomplete_media_loads_after_jquery_init():
     field = Address._meta.get_field("selected_state")
-    widget = DependentAutocompleteSelect(
+    widget = UnfoldAdminDependentAutocompleteSelect(
         field,
         site,
         parent_field_name="selected_country",

--- a/tests/test_dependent_autocomplete.py
+++ b/tests/test_dependent_autocomplete.py
@@ -1,0 +1,391 @@
+import json
+
+from django.contrib.admin.sites import site
+from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied
+from django.test import Client, RequestFactory
+from django.urls import reverse
+
+import pytest
+from example.admin import AddressAdmin, CityAdmin, CountryAdmin, StateAdmin
+from example.models import Address, City, Country, Person, PersonLocation, State
+from unfold.admin import GenericTabularInline, ModelAdmin, TabularInline
+from unfold.sites import UnfoldAdminSite
+from unfold.views import DependentAutocompleteJsonView
+from unfold.widgets import DependentAutocompleteSelect
+
+
+@pytest.fixture
+def geography(db):
+    united_states = Country.objects.create(name="United States")
+    states = {
+        "california": State.objects.create(country=united_states, name="California"),
+        "texas": State.objects.create(country=united_states, name="Texas"),
+    }
+    cities = {
+        "san_francisco": City.objects.create(
+            state=states["california"], name="San Francisco"
+        ),
+        "los_angeles": City.objects.create(
+            state=states["california"], name="Los Angeles"
+        ),
+        "houston": City.objects.create(state=states["texas"], name="Houston"),
+    }
+    return {
+        "united_states": united_states,
+        "states": states,
+        "cities": cities,
+    }
+
+
+@pytest.fixture
+def dependent_admin_client(db):
+    user = get_user_model().objects.create_superuser(
+        "admin", "admin@example.com", "password"
+    )
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+def dependent_params(field_name, parent, **extra):
+    return {
+        "term": "",
+        "app_label": "example",
+        "model_name": "address",
+        "field_name": field_name,
+        "dependent_parent": str(parent.pk),
+        **extra,
+    }
+
+
+def result_texts(response):
+    return [result["text"] for result in response.json()["results"]]
+
+
+def test_dependent_autocomplete_media_loads_after_jquery_init():
+    field = Address._meta.get_field("selected_state")
+    widget = DependentAutocompleteSelect(
+        field,
+        site,
+        parent_field_name="selected_country",
+        source_admin=AddressAdmin(Address, site),
+    )
+    rendered_js = str(widget.media["js"])
+
+    assert rendered_js.index("jquery.init.js") < rendered_js.index(
+        "dependent-autocomplete.js"
+    )
+
+
+def test_shorthand_dependency_is_normalized():
+    class ShorthandAdmin(ModelAdmin):
+        autocomplete_dependencies = {"selected_city": "selected_state"}
+
+    model_admin = ShorthandAdmin(Address, UnfoldAdminSite())
+
+    assert model_admin.get_autocomplete_dependency_config("selected_city") == {
+        "depends_on": "selected_state",
+        "lookup": "selected_state",
+    }
+
+
+@pytest.mark.django_db
+def test_dependent_autocomplete_filters_by_configured_lookup(
+    dependent_admin_client, geography
+):
+    united_states = geography["united_states"]
+    california = geography["states"]["california"]
+    url = reverse("admin:example_address_dependent_autocomplete")
+
+    state_response = dependent_admin_client.get(
+        url,
+        dependent_params("selected_state", united_states),
+    )
+    city_response = dependent_admin_client.get(
+        url,
+        dependent_params("selected_city", california),
+    )
+    search_response = dependent_admin_client.get(
+        url,
+        dependent_params("selected_city", california, term="San"),
+    )
+
+    assert state_response.status_code == 200
+    assert result_texts(state_response) == ["California", "Texas"]
+    assert result_texts(city_response) == ["Los Angeles", "San Francisco"]
+    assert result_texts(search_response) == ["San Francisco"]
+
+
+@pytest.mark.django_db
+def test_empty_parent_returns_no_results(dependent_admin_client, geography):
+    response = dependent_admin_client.get(
+        reverse("admin:example_address_dependent_autocomplete"),
+        dependent_params(
+            "selected_state", geography["united_states"], dependent_parent=""
+        ),
+    )
+
+    assert response.status_code == 200
+    assert result_texts(response) == []
+
+
+@pytest.mark.django_db
+def test_normal_autocomplete_ignores_dependent_parent(
+    dependent_admin_client, geography
+):
+    response = dependent_admin_client.get(
+        reverse("admin:autocomplete"),
+        {
+            "term": "Los",
+            "app_label": "example",
+            "model_name": "address",
+            "field_name": "backup_city",
+            "dependent_parent": str(geography["states"]["california"].pk),
+        },
+    )
+
+    assert response.status_code == 200
+    assert result_texts(response) == ["Los Angeles"]
+
+
+@pytest.mark.django_db
+def test_dependent_autocomplete_requires_permissions(geography):
+    user = get_user_model().objects.create_user(
+        "staff", "staff@example.com", "password", is_staff=True
+    )
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(
+        reverse("admin:example_address_dependent_autocomplete"),
+        dependent_params("selected_state", geography["united_states"]),
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_change_form_preserves_chained_dependent_values(
+    dependent_admin_client, geography
+):
+    states = geography["states"]
+    cities = geography["cities"]
+    address = Address.objects.create(
+        selected_country=geography["united_states"],
+        selected_state=states["california"],
+        selected_city=cities["san_francisco"],
+        street="1 Market Street",
+    )
+
+    response = dependent_admin_client.get(
+        reverse("admin:example_address_change", args=[address.pk])
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert (
+        f'<option value="{states["california"].pk}" selected>California</option>'
+        in content
+    )
+    assert (
+        f'<option value="{cities["san_francisco"].pk}" selected>San Francisco</option>'
+        in content
+    )
+    assert 'data-dependent-autocomplete-parent="selected_country"' in content
+    assert 'data-dependent-autocomplete-parent="selected_state"' in content
+
+
+@pytest.mark.parametrize(
+    ("dependencies", "autocomplete_fields", "expected_ids"),
+    [
+        (["selected_city"], ["selected_city"], ["unfold.E001"]),
+        ({"selected_city": "missing"}, ["selected_city"], ["unfold.E004"]),
+        (
+            {"selected_city": {"depends_on": "selected_state", "lookup": "name"}},
+            ["selected_city"],
+            ["unfold.E007"],
+        ),
+        (
+            {
+                "selected_city": {
+                    "depends_on": "selected_state",
+                    "lookup": "state__country",
+                }
+            },
+            ["selected_city"],
+            ["unfold.E008"],
+        ),
+        ({"selected_city": "selected_state"}, ["selected_state"], ["unfold.E003"]),
+        ({"selected_city": "street"}, ["selected_city"], ["unfold.E005"]),
+        (
+            {"selected_city": {"depends_on": "selected_state", "lookup": "country"}},
+            ["selected_city"],
+            ["unfold.E006"],
+        ),
+        ({1: "selected_state"}, ["selected_city"], ["unfold.E002"]),
+        ({"selected_city": 123}, ["selected_city"], ["unfold.E002"]),
+        (
+            {"selected_city": {"depends_on": "selected_state"}},
+            ["selected_city"],
+            ["unfold.E002"],
+        ),
+    ],
+)
+def test_invalid_autocomplete_dependencies_raise_system_checks(
+    dependencies, autocomplete_fields, expected_ids
+):
+    class InvalidAdmin(ModelAdmin):
+        pass
+
+    InvalidAdmin.autocomplete_fields = autocomplete_fields
+    InvalidAdmin.autocomplete_dependencies = dependencies
+
+    model_admin = InvalidAdmin(Address, UnfoldAdminSite())
+    errors = model_admin._check_autocomplete_dependencies()
+
+    assert [error.id for error in errors] == expected_ids
+
+
+@pytest.mark.django_db
+def test_inline_dependent_autocomplete_without_registered_model(
+    dependent_admin_client, geography
+):
+    assert not site.is_registered(PersonLocation)
+    url = reverse("admin:example_person_personlocationinline_dependent_autocomplete")
+    california = geography["states"]["california"]
+
+    response = dependent_admin_client.get(
+        url,
+        {
+            "term": "",
+            "app_label": "example",
+            "model_name": "personlocation",
+            "field_name": "selected_city",
+            "dependent_parent": str(california.pk),
+        },
+    )
+
+    assert response.status_code == 200
+    assert result_texts(response) == ["Los Angeles", "San Francisco"]
+
+
+@pytest.mark.django_db
+def test_standalone_modeladmin_does_not_control_inline_config(geography):
+    admin_site = UnfoldAdminSite(name="partial")
+    admin_site.register(Country, CountryAdmin)
+    admin_site.register(State, StateAdmin)
+    admin_site.register(City, CityAdmin)
+
+    class PartialLocationAdmin(ModelAdmin):
+        autocomplete_fields = ["selected_state"]
+        autocomplete_dependencies = {
+            "selected_state": {
+                "depends_on": "selected_country",
+                "lookup": "country",
+            },
+        }
+
+    class FullLocationInline(TabularInline):
+        model = PersonLocation
+        autocomplete_fields = ["selected_state", "selected_city"]
+        autocomplete_dependencies = {
+            "selected_state": {
+                "depends_on": "selected_country",
+                "lookup": "country",
+            },
+            "selected_city": {
+                "depends_on": "selected_state",
+                "lookup": "state",
+            },
+        }
+
+    class HostAdmin(ModelAdmin):
+        inlines = [FullLocationInline]
+
+    admin_site.register(PersonLocation, PartialLocationAdmin)
+    admin_site.register(Person, HostAdmin)
+
+    inline = FullLocationInline(Person, admin_site)
+    standalone = PartialLocationAdmin(PersonLocation, admin_site)
+    user = get_user_model().objects.create_superuser(
+        "inline-admin", "inline@example.com", "password"
+    )
+    factory = RequestFactory()
+    params = {
+        "term": "",
+        "app_label": "example",
+        "model_name": "personlocation",
+        "field_name": "selected_city",
+        "dependent_parent": str(geography["states"]["california"].pk),
+    }
+
+    def request():
+        http_request = factory.get("/dependent-autocomplete/", params)
+        http_request.user = user
+        return http_request
+
+    inline_response = DependentAutocompleteJsonView.as_view(
+        admin_site=admin_site,
+        source_model_admin=inline,
+    )(request())
+
+    assert inline.get_dependent_autocomplete_url_name() == (
+        "example_person_fulllocationinline_dependent_autocomplete"
+    )
+    assert standalone.get_dependent_autocomplete_url_name() == (
+        "example_personlocation_dependent_autocomplete"
+    )
+    assert inline_response.status_code == 200
+    assert [
+        result["text"] for result in json.loads(inline_response.content)["results"]
+    ] == ["Los Angeles", "San Francisco"]
+    with pytest.raises(PermissionDenied):
+        DependentAutocompleteJsonView.as_view(
+            admin_site=admin_site,
+            source_model_admin=standalone,
+        )(request())
+
+
+def test_inline_autocomplete_dependencies_system_checks_run():
+    class InvalidInline(TabularInline):
+        model = PersonLocation
+        autocomplete_fields = ["selected_city"]
+        autocomplete_dependencies = {"selected_city": "missing"}
+
+    inline = InvalidInline(Person, UnfoldAdminSite())
+    errors = inline.check()
+
+    assert "unfold.E004" in [error.id for error in errors]
+
+
+def test_generic_inline_autocomplete_dependencies_system_checks_run():
+    class InvalidGenericInline(GenericTabularInline):
+        model = PersonLocation
+        autocomplete_fields = ["selected_city"]
+        autocomplete_dependencies = {"selected_city": "missing"}
+
+    inline = InvalidGenericInline(Person, UnfoldAdminSite())
+    errors = inline.check()
+
+    assert "unfold.E004" in [error.id for error in errors]
+
+
+def test_duplicate_inline_dependent_autocomplete_url_names():
+    class LocationInline(TabularInline):
+        model = PersonLocation
+        autocomplete_fields = ["selected_state"]
+        autocomplete_dependencies = {
+            "selected_state": {
+                "depends_on": "selected_country",
+                "lookup": "country",
+            },
+        }
+
+    class DuplicateInlineHost(ModelAdmin):
+        inlines = [LocationInline, LocationInline]
+
+    model_admin = DuplicateInlineHost(Person, UnfoldAdminSite())
+    errors = model_admin.check()
+
+    assert "unfold.E009" in [error.id for error in errors]

--- a/tests/test_dependent_autocomplete.py
+++ b/tests/test_dependent_autocomplete.py
@@ -1,14 +1,15 @@
 import json
+from http import HTTPStatus
 
+import pytest
 from django.contrib.admin.sites import site
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.test import Client, RequestFactory
 from django.urls import reverse
-
-import pytest
 from example.admin import AddressAdmin, CityAdmin, CountryAdmin, StateAdmin
 from example.models import Address, City, Country, Person, PersonLocation, State
+
 from unfold.admin import GenericTabularInline, ModelAdmin, TabularInline
 from unfold.sites import UnfoldAdminSite
 from unfold.views import DependentAutocompleteJsonView
@@ -111,7 +112,7 @@ def test_dependent_autocomplete_filters_by_configured_lookup(
         dependent_params("selected_city", california, term="San"),
     )
 
-    assert state_response.status_code == 200
+    assert state_response.status_code == HTTPStatus.OK
     assert result_texts(state_response) == ["California", "Texas"]
     assert result_texts(city_response) == ["Los Angeles", "San Francisco"]
     assert result_texts(search_response) == ["San Francisco"]
@@ -126,8 +127,73 @@ def test_empty_parent_returns_no_results(dependent_admin_client, geography):
         ),
     )
 
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     assert result_texts(response) == []
+
+
+@pytest.mark.django_db
+def test_unconfigured_field_on_dependent_url_is_forbidden(
+    dependent_admin_client, geography
+):
+    response = dependent_admin_client.get(
+        reverse("admin:example_address_dependent_autocomplete"),
+        dependent_params("backup_city", geography["states"]["california"]),
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_mismatched_source_model_on_dependent_url_is_forbidden(
+    dependent_admin_client, geography
+):
+    response = dependent_admin_client.get(
+        reverse("admin:example_address_dependent_autocomplete"),
+        {
+            "term": "",
+            "app_label": "example",
+            "model_name": "personlocation",
+            "field_name": "selected_city",
+            "dependent_parent": str(geography["states"]["california"].pk),
+        },
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_invalid_parent_pk_returns_no_results(dependent_admin_client, geography):
+    response = dependent_admin_client.get(
+        reverse("admin:example_address_dependent_autocomplete"),
+        dependent_params(
+            "selected_state",
+            geography["united_states"],
+            dependent_parent="not-a-pk",
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert result_texts(response) == []
+
+
+@pytest.mark.django_db
+def test_dependent_autocomplete_preserves_search_distinct(
+    dependent_admin_client, geography, monkeypatch
+):
+    def get_search_results(self, request, queryset, search_term):
+        queryset, _use_distinct = ModelAdmin.get_search_results(
+            self, request, queryset, search_term
+        )
+        return queryset, True
+
+    monkeypatch.setattr(CityAdmin, "get_search_results", get_search_results)
+    response = dependent_admin_client.get(
+        reverse("admin:example_address_dependent_autocomplete"),
+        dependent_params("selected_city", geography["states"]["california"]),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert result_texts(response) == ["Los Angeles", "San Francisco"]
 
 
 @pytest.mark.django_db
@@ -145,7 +211,7 @@ def test_normal_autocomplete_ignores_dependent_parent(
         },
     )
 
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     assert result_texts(response) == ["Los Angeles"]
 
 
@@ -162,7 +228,7 @@ def test_dependent_autocomplete_requires_permissions(geography):
         dependent_params("selected_state", geography["united_states"]),
     )
 
-    assert response.status_code == 403
+    assert response.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.django_db
@@ -182,7 +248,7 @@ def test_change_form_preserves_chained_dependent_values(
         reverse("admin:example_address_change", args=[address.pk])
     )
 
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     content = response.content.decode()
     assert (
         f'<option value="{states["california"].pk}" selected>California</option>'
@@ -266,7 +332,7 @@ def test_inline_dependent_autocomplete_without_registered_model(
         },
     )
 
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     assert result_texts(response) == ["Los Angeles", "San Francisco"]
 
 
@@ -336,7 +402,7 @@ def test_standalone_modeladmin_does_not_control_inline_config(geography):
     assert standalone.get_dependent_autocomplete_url_name() == (
         "example_personlocation_dependent_autocomplete"
     )
-    assert inline_response.status_code == 200
+    assert inline_response.status_code == HTTPStatus.OK
     assert [
         result["text"] for result in json.loads(inline_response.content)["results"]
     ] == ["Los Angeles", "San Francisco"]


### PR DESCRIPTION
## Summary

Adds dependent autocomplete support on top of Django Admin's existing `autocomplete_fields`.

Supports:
- ForeignKey dependencies
- Shorthand and explicit `depends_on` / `lookup` configuration
- Chained dependencies
- ModelAdmin and InlineModelAdmin
- Native Django autocomplete permissions, search, pagination, and JSON responses

Example:

```python
autocomplete_fields = ["state", "city"]

autocomplete_dependencies = {
    "state": "country",
    "city": "state",
}
```

For cases where the form field name differs from the related model lookup:

```python
autocomplete_dependencies = {
    "city": {
        "depends_on": "selected_state",
        "lookup": "state",
    }
}
```

### Demo

https://github.com/user-attachments/assets/a35e28c2-a835-4441-bbec-5d635f2a5697



## Test plan

- Added focused tests for dependent autocomplete behavior, configuration validation, permissions, inline ownership, invalid parent values, and native autocomplete compatibility.
- Verified with Django 5.2 and Django 6.0 through the project's tox environments.
- Full test suites pass with the required coverage threshold.
- `pre-commit run --all-files` passes.
- Manually smoke-tested regular admin forms and inline formsets in a local Unfold test project.

## Use of AI

Yes. AI was used to assist with the initial implementation, test generation, and code review. I manually reviewed and refined the resulting code, verified it against the project's existing patterns, ran the full test suite and pre-commit checks, and manually smoke-tested the feature.